### PR TITLE
dial: check DNS questions in tests

### DIFF
--- a/dial/dial_test.go
+++ b/dial/dial_test.go
@@ -8,21 +8,23 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"strconv"
 	"testing"
+
+	"golang.org/x/net/dns/dnsmessage"
 
 	"mellium.im/xmpp/dial"
 	"mellium.im/xmpp/jid"
 )
 
-// TODO: accept DNS connections and returned canned responses so that we can
-// check DNS request type made in the tests.
+// TODO: reply with canned DNS responses so that we can check followup queries.
 
 var dialTests = [...]struct {
-	dialer     *dial.Dialer
-	addr       string
-	socketAddr string
-	resolved   bool
+	dialer       *dial.Dialer
+	addr         string
+	socketAddr   string
+	dnsQuestions []dnsmessage.Question
 }{
 	// IP no port
 	0: {addr: "::1", socketAddr: "[::1]:5222"},
@@ -58,37 +60,85 @@ var dialTests = [...]struct {
 	},
 
 	// DNS no port
-	8: {addr: "example.net", resolved: true},
+	8: {
+		addr: "example.net",
+		dnsQuestions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName("_xmpps-client._tcp.example.net."),
+			Type:  dnsmessage.TypeSRV,
+			Class: dnsmessage.ClassINET,
+		}},
+	},
 	9: {
-		dialer: &dial.Dialer{NoLookup: true},
-		addr:   "example.net", resolved: true,
+		dialer: &dial.Dialer{S2S: true},
+		addr:   "example.org",
+		dnsQuestions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName("_xmpps-server._tcp.example.org."),
+			Type:  dnsmessage.TypeSRV,
+			Class: dnsmessage.ClassINET,
+		}},
 	},
 	10: {
-		dialer: &dial.Dialer{NoLookup: false, S2S: true},
-		addr:   "example.net", resolved: true,
+		dialer: &dial.Dialer{NoLookup: true},
+		addr:   "example.com",
+		dnsQuestions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName("example.com."),
+			Type:  dnsmessage.TypeAAAA,
+			Class: dnsmessage.ClassINET,
+		}},
 	},
 	11: {
 		dialer: &dial.Dialer{NoLookup: true, S2S: true},
-		addr:   "example.net", resolved: true,
+		addr:   "example.net",
+		dnsQuestions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName("example.net."),
+			Type:  dnsmessage.TypeAAAA,
+			Class: dnsmessage.ClassINET,
+		}},
 	},
 
-	// DNS with port
-	12: {addr: "example.net:123", resolved: true},
+	//// DNS with port
+	12: {
+		addr: "example.net:123",
+		dnsQuestions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName("example.net."),
+			Type:  dnsmessage.TypeAAAA,
+			Class: dnsmessage.ClassINET,
+		}},
+	},
 	13: {
 		dialer: &dial.Dialer{NoLookup: true},
-		addr:   "example.net:123", resolved: true,
+		addr:   "example.org:123",
+		dnsQuestions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName("example.org."),
+			Type:  dnsmessage.TypeAAAA,
+			Class: dnsmessage.ClassINET,
+		}},
 	},
 	14: {
 		dialer: &dial.Dialer{NoLookup: false, S2S: true},
-		addr:   "example.net:123", resolved: true,
+		addr:   "example.com:123",
+		dnsQuestions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName("example.com."),
+			Type:  dnsmessage.TypeAAAA,
+			Class: dnsmessage.ClassINET,
+		}},
 	},
 	15: {
 		dialer: &dial.Dialer{NoLookup: true, S2S: true},
-		addr:   "example.net:123", resolved: true,
+		addr:   "example.net:123",
+		dnsQuestions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName("example.net."),
+			Type:  dnsmessage.TypeAAAA,
+			Class: dnsmessage.ClassINET,
+		}},
 	},
 }
 
 func TestDial(t *testing.T) {
+	if testing.Short() {
+		t.Skipf("skipping %d subtests in short mode", len(dialTests))
+	}
+
 	for i, tc := range dialTests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -120,8 +170,9 @@ func TestDial(t *testing.T) {
 			if server.Dialed != tc.socketAddr {
 				t.Errorf("Dialed wrong address: want=%q, got=%q", tc.socketAddr, server.Dialed)
 			}
-			if server.Resolved != tc.resolved {
-				t.Errorf("Wrong value for resolved: want=%t, got=%t", tc.resolved, server.Resolved)
+
+			if !reflect.DeepEqual(server.Questions, tc.dnsQuestions) {
+				t.Errorf("Wrong dns questions:\nwant=%v,\n got=%v", tc.dnsQuestions, server.Questions)
 			}
 		})
 	}


### PR DESCRIPTION
Tests for the [`dial`](https://godoc.org/mellium.im/xmpp/dial) package were sadly incomplete. This is the start of a way to test the public interface that can replace some of the tests for internal components and do a better job of testing end-to-end without requiring actual integration tests that need external resources.

It is rather slow and requires a lot of extra testing infrastructure that makes me a bit nervous, so I'm unsure if I want to merge it yet.