### PR TITLE
.builds: add DCO check

### DIFF
--- a/.builds/dco.yml
+++ b/.builds/dco.yml
@@ -1,0 +1,25 @@
+image: alpine/edge
+packages:
+  - git
+sources:
+  - https://github.com/mellium/xmpp.git
+tasks:
+  - dco: |
+      git version
+      cd xmpp/
+      function on_err {
+        cat <<EOF
+      Failed to sign the Developer Certificate of Origin (DCO)!
+      Please read the file "DCO" and then, if you agree, sign each of your commits
+      using:
+
+          git commit -s
+
+      Or quickly sign the previous commit with:
+
+          git commit --amend -s --no-edit
+      EOF
+      }
+      trap on_err ERR
+
+      [[ "$(git log --no-merges --pretty='%(trailers:key=Signed-off-by,valueonly)' master..)" ]]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,23 @@ If you're not sure where to begin, grab any of the issues labeled
 ask!
 
 
+## Sign your work
+
+All commits must be signed before they can be accepted. Your signature
+indicates that you have the right to contribute the work and that it can be
+contributed as open source. The exact rules can be viewed at
+[developercertificate.org], or in the file [DCO].
+
+To add your signature, add a line like the following to the end of your commit
+message with your name and email:
+
+    Signed-off-by: John Smith <john.smith@example.net>
+
+You can add this line easily using Git by committing with `git commit -s`.
+If you forget to add a signature to a commit, quickly add it to the latest
+commit with `git commit --amend -s --no-edit`.
+
+
 ## License
 
 The package may be used under the terms of the BSD 2-Clause License a copy of
@@ -27,4 +44,6 @@ conditions.
 
 [issues]: https://github.com/mellium/xmpp/issues
 [starter]: https://github.com/mellium/xmpp/labels/starter
+[developercertificate.org]: https://developercertificate.org/
+[DCO]: ./DCO
 [LICENSE]: ./LICENSE

--- a/DCO
+++ b/DCO
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Adds an experimental DCO check. I am unsure if I want to use the [DCO](https://developercertificate.org/) for this repo, so feedback would be appreciated.