### PR TITLE
dial: wait for server to shut down before finishing tests

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -2,7 +2,7 @@ image: freebsd/latest
 packages:
   - go
 sources:
-  - https://github.com/mellium/xmpp.git
+  - https://github.com/mellium/xmpp
 tasks:
   - setup: |
       go version

--- a/dial/dial_test.go
+++ b/dial/dial_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"golang.org/x/net/dns/dnsmessage"
 
@@ -141,10 +142,10 @@ func TestDial(t *testing.T) {
 
 	for i, tc := range dialTests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
-			server := newServer(t)
+			server := newServer(ctx, t)
 
 			if tc.dialer == nil {
 				tc.dialer = &dial.Dialer{}
@@ -166,6 +167,8 @@ func TestDial(t *testing.T) {
 					}
 				}
 			}()
+
+			<-server.ctx.Done()
 
 			if server.Dialed != tc.socketAddr {
 				t.Errorf("Dialed wrong address: want=%q, got=%q", tc.socketAddr, server.Dialed)


### PR DESCRIPTION
The append is sometimes happening after the tests have completed,
resulting in a failure. Wait until the DNS server goroutine shuts down
to check the test results.