### PR TITLE
uri: new package implementing XMPP URI's and IRI's

### DIFF
--- a/uri/export_test.go
+++ b/uri/export_test.go
@@ -1,0 +1,7 @@
+// Copyright 2019 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package uri
+
+var TestErrBadScheme = errBadScheme

--- a/uri/iri.go
+++ b/uri/iri.go
@@ -1,0 +1,211 @@
+// Copyright 2019 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+// Package uri parses XMPP URI and IRI's as defined in RFC 5122.
+//
+// It also provides easy access to query components defined in XEP-0147: XMPP
+// URI Scheme Query Components and the XMPP URI/IRI Querytypes registry.
+package uri
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"mellium.im/xmpp/jid"
+)
+
+var (
+	errBadScheme = errors.New("uri: expected scheme xmpp")
+)
+
+// URI is a parsed XMPP URI or IRI.
+type URI struct {
+	*url.URL
+
+	ToAddr   jid.JID
+	AuthAddr jid.JID
+	Action   string
+}
+
+// TODO: encoding and escaping, see
+// https://tools.ietf.org/html/rfc5122#section-2.7.2
+
+// Parse parses rawuri into a URI structure.
+func Parse(rawuri string) (*URI, error) {
+	u, err := url.Parse(rawuri)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Scheme != "xmpp" {
+		return nil, errBadScheme
+	}
+
+	uri := &URI{
+		URL: u,
+	}
+
+	if u.Host != "" {
+		// If an authentication address was provided (ie. the URI started with
+		// `xmpp://'), parse it out and take the recipient address from the path.
+
+		uri.AuthAddr, err = jid.New(u.User.Username(), u.Hostname(), "")
+		if err != nil {
+			return nil, err
+		}
+		if u.Path != "" {
+			// Strip the root / and use the path as the JID.
+			iri, err := toIRI(u.Path[1:], false)
+			if err != nil {
+				return nil, err
+			}
+			uri.ToAddr, err = jid.Parse(iri)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		// If no auth address was provided (ie. the URI started with `xmpp:') take
+		// the recipient address from the opaque part and ignore the user info.
+		iri, err := toIRI(u.Opaque, true)
+		if err != nil {
+			return nil, err
+		}
+		uri.ToAddr, err = jid.Parse(iri)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for k, v := range u.Query() {
+		if len(v) == 0 || len(v) == 1 && v[0] == "" {
+			uri.Action = k
+			break
+		}
+	}
+
+	return uri, err
+}
+
+// String reassembles the URI or IRI Into a valid IRI string.
+func (u *URI) String() string {
+	iri, _ := toIRI(u.URL.String(), true)
+	return iri
+}
+
+// toIRI converts the URI to a valid IRI using the algorithm defined in RFC 3987
+// §3.2.
+// It does not validate that the input is a valid URI.
+func toIRI(u string, needsUnescape bool) (string, error) {
+	// 1.  Represent the URI as a sequence of octets in US-ASCII.
+	//
+	// 2.  Convert all percent-encodings ("%" followed by two hexadecimal
+	//     digits) to the corresponding octets, except those corresponding
+	//     to "%", characters in "reserved", and characters in US-ASCII not
+	//     allowed in URIs.
+	// TODO: using PathUnescape to create a new string is very inefficient, but
+	// it's the only method available in the standard library for this.
+	// In the future we should write an escape/unescaper that implements
+	// "golang.org/x/text/transform".Transformer or simply appends to a buffer or
+	// byte slice so that the next step can also be done in the same iteration
+	// without creating yet another builder.
+	var err error
+	if needsUnescape {
+		u, err = url.PathUnescape(u)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// 3. Re-percent-encode any octet produced in step 2 that is not part
+	//    of a strictly legal UTF-8 octet sequence.
+	// 4. Re-percent-encode all octets produced in step 3 that in UTF-8
+	//    represent characters that are not appropriate according to
+	//    sections 2.2, 4.1, and 6.1.
+	u = escapeInvalidUTF8(u)
+
+	// 5. Interpret the resulting octet sequence as a sequence of characters
+	//    encoded in UTF-8.
+	// TODO:
+
+	return u, nil
+}
+
+// escapeInvalidUTF8 is like strings.ToValidUTF8 except that it replaces invalid
+// UTF8 with % encoded versions of the invalid bytes instead of a fixed string.
+func escapeInvalidUTF8(s string) string {
+	// This function is a modified form of code copied from
+	// go/src/strings/strings.go under the terms of Go's BSD license.
+	// See the file LICENSE-GO for details.
+	var b strings.Builder
+
+	for i, c := range s {
+		if !runeDisallowed(c, 1) {
+			continue
+		}
+
+		r, wid := utf8.DecodeRuneInString(s[i:])
+		if runeDisallowed(r, wid) {
+			// 3 bytes in %AB.
+			b.Grow(len(s) + 3*wid)
+			_, err := b.WriteString(s[:i])
+			if err != nil {
+				panic(fmt.Errorf("error writing string to buffer: %w", err))
+			}
+			s = s[i:]
+			break
+		}
+	}
+
+	// Fast path for unchanged input
+	if b.Cap() == 0 { // didn't call b.Grow above
+		return s
+	}
+
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c < utf8.RuneSelf {
+			i++
+			err := b.WriteByte(c)
+			if err != nil {
+				panic(fmt.Errorf("error writing byte to buffer: %w", err))
+			}
+			continue
+		}
+		r, wid := utf8.DecodeRuneInString(s[i:])
+		if runeDisallowed(r, wid) {
+			for j := 0; j < wid; j++ {
+				fmt.Fprintf(&b, "%%%0X", s[i+j:i+j+1])
+			}
+			i += wid
+			continue
+		}
+		_, err := b.WriteString(s[i : i+wid])
+		if err != nil {
+			panic(fmt.Errorf("error writing remaining string to buffer: %w", err))
+		}
+		i += wid
+	}
+
+	return b.String()
+}
+
+func runeDisallowed(r rune, wid int) bool {
+	switch r {
+	case utf8.RuneError:
+		// the various utf8.Decode methods return wid==1 on invalid rune. 0 means
+		// empty string, other values won't be returned.
+		return wid == 1
+	case '\u200e', '\u200f', '\u202a', '\u202b', '\u202d', '\u202e', '\u202c':
+		// RFC 3987 §4.1:
+		//
+		//     IRIs MUST NOT contain bidirectional formatting characters (LRM, RLM,
+		//     LRE, RLE, LRO, RLO, and PDF).
+		return true
+	}
+	return false
+}

--- a/uri/iri_test.go
+++ b/uri/iri_test.go
@@ -1,0 +1,211 @@
+// Copyright 2019 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package uri_test
+
+import (
+	"errors"
+	"net/url"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"mellium.im/xmpp/jid"
+	"mellium.im/xmpp/uri"
+)
+
+var parseTests = [...]struct {
+	raw    string
+	iri    string
+	u      *uri.URI
+	err    error
+	values url.Values
+}{
+	0: {err: uri.TestErrBadScheme},
+	1: {raw: "mailto:badscheme@example.net", err: uri.TestErrBadScheme},
+	2: {
+		raw: "xmpp:feste@example.net",
+		u:   &uri.URI{ToAddr: jid.MustParse("feste@example.net")},
+	},
+	3: {
+		raw: "xmpp://feste@example.net",
+		u:   &uri.URI{AuthAddr: jid.MustParse("feste@example.net")},
+	},
+	4: {
+		raw: "xmpp:feste@example.net/ilyria",
+		u:   &uri.URI{ToAddr: jid.MustParse("feste@example.net/ilyria")},
+	},
+	5: {
+		raw: "xmpp://feste@example.net/olivia@example.org",
+		u: &uri.URI{
+			AuthAddr: jid.MustParse("feste@example.net"),
+			ToAddr:   jid.MustParse("olivia@example.org"),
+		},
+	},
+	6: {
+		raw: "xmpp:example-node@example.com?message",
+		u: &uri.URI{
+			ToAddr: jid.MustParse("example-node@example.com"),
+			Action: "message",
+		},
+		values: url.Values{
+			"message": []string{""},
+		},
+	},
+	7: {
+		raw: "xmpp:example-node@example.com?message;subject=Hello%20World",
+		iri: "xmpp:example-node@example.com?message;subject=Hello World",
+		u: &uri.URI{
+			ToAddr: jid.MustParse("example-node@example.com"),
+			Action: "message",
+		},
+		values: url.Values{
+			"message": []string{""},
+			"subject": []string{"Hello World"},
+		},
+	},
+	8: {
+		raw: "xmpp:example-node@example.com?message&subject=Hello%20World",
+		iri: "xmpp:example-node@example.com?message&subject=Hello World",
+		u: &uri.URI{
+			ToAddr: jid.MustParse("example-node@example.com"),
+			Action: "message",
+		},
+		values: url.Values{
+			"message": []string{""},
+			"subject": []string{"Hello World"},
+		},
+	},
+	9: {
+		// Tests that JID errors in the xmpp: parsing path are passed through.
+		raw: "xmpp:feste@/ilyria",
+		err: jidErr("feste@/ilyria"),
+	},
+	10: {
+		// Tests that JID errors in the xmpp:// parsing path are passed through.
+		raw: "xmpp://b&d@example.net",
+		err: jidErr("b&d@example.net"),
+	},
+	11: {
+		// Tests that recipient JID errors in the xmpp:// parsing path are passed
+		// through.
+		raw: "xmpp://feste@example.net/b&d@example.net",
+		err: jidErr("b&d@example.net"),
+	},
+	12: {
+		raw: "xmpp://nasty!%23$%25()*+,-.;=%3F%5B%5C%5D%5E_%60%7B%7C%7D~node@example.com/node@example.com/repulsive%20!%23%22$%25&'()*+,-.%2F:;%3C=%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~resource",
+		iri: "xmpp://nasty!#$%()*+,-.;=?[\\]^_`{|}~node@example.com/node@example.com/repulsive !#\"$%&'()*+,-./:;<=>?@[\\]^_`{|}~resource",
+		u: &uri.URI{
+			AuthAddr: jid.MustParse("nasty!#$%()*+,-.;=?[\\]^_`{|}~node@example.com"),
+			ToAddr:   jid.MustParse("node@example.com/repulsive !#\"$%&'()*+,-./:;<=>?@[\\]^_`{|}~resource"),
+		},
+	},
+	13: {
+		raw: "xmpp:node@example.com/repulsive%20!%23%22$%25&'()*+,-.%2F:;%3C=%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~resource",
+		iri: "xmpp:node@example.com/repulsive !#\"$%&'()*+,-./:;<=>?@[\\]^_`{|}~resource",
+		u: &uri.URI{
+			ToAddr: jid.MustParse("node@example.com/repulsive !#\"$%&'()*+,-./:;<=>?@[\\]^_`{|}~resource"),
+		},
+	},
+	14: {
+		raw: "xmpp:test%%bad",
+		err: func() error {
+			_, err := url.PathUnescape("xmpp:%%b")
+			return err
+		}(),
+	},
+
+	// Tests from RFC 3987 §3.2.1
+	15: {
+		raw: "xmpp:example.org/D%C3%BCrst",
+		iri: "xmpp:example.org/Dürst",
+		u: &uri.URI{
+			ToAddr: jid.MustParse("example.org/Dürst"),
+		},
+	},
+	16: {
+		raw: "xmpp:example.org/D%FCrst",
+		iri: "xmpp:example.org/D%FCrst",
+		u: &uri.URI{
+			ToAddr: jid.MustParse("example.org/D%FCrst"),
+		},
+	},
+	17: {
+		raw: "xmpp:xn--99zt52a.example.org/%e2%80%ae",
+		iri: "xmpp:xn--99zt52a.example.org/%E2%80%AE",
+		u: &uri.URI{
+			ToAddr: jid.MustParse("\u7D0D\u8C46.example.org/%E2%80%AE"),
+		},
+	},
+}
+
+func TestParse(t *testing.T) {
+	for i, tc := range parseTests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			u, err := uri.Parse(tc.raw)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("unexpected error: want=%v, got=%v", tc.err, err)
+			}
+			if err != nil {
+				return
+			}
+
+			// Check the output of the IRI method.
+			// As a shortcut, if the expected IRI is the empty string check against
+			// the raw string (nothing in the URI needs to be decoded, so IRI()
+			// should return the original).
+			if tc.iri == "" {
+				tc.iri = tc.raw
+			}
+			if iri := u.String(); tc.iri != iri {
+				t.Errorf("unexpected IRI decoded: want=%q, got=%q", tc.iri, iri)
+			}
+
+			if !u.AuthAddr.Equal(tc.u.AuthAddr) {
+				t.Errorf("unexpected auth address: want=%v, got=%v", tc.u.AuthAddr, u.AuthAddr)
+			}
+
+			if !u.ToAddr.Equal(tc.u.ToAddr) {
+				t.Errorf("unexpected recipient address: want=%v, got=%v", tc.u.ToAddr, u.ToAddr)
+			}
+
+			if u.Action != tc.u.Action {
+				t.Errorf("wrong action: want=%v, got=%v", tc.u.Action, u.Action)
+			}
+
+			if tc.values == nil {
+				tc.values = make(map[string][]string)
+			}
+			if values := u.URL.Query(); !reflect.DeepEqual(tc.values, values) {
+				t.Errorf("unexpected query values:want=%v, got=%v", tc.values, values)
+			}
+		})
+	}
+}
+
+func TestParseErrorsReturned(t *testing.T) {
+	const badURL = " xmpp://feste@example.net"
+	_, err := uri.Parse(badURL)
+	_, expected := url.Parse(badURL)
+	if expected == nil {
+		t.Fatal("test requires an invalid URL")
+	}
+	if err.Error() != expected.Error() {
+		t.Fatalf("expected URL parse errors to be returned: want=%v, got=%v", expected, err)
+	}
+}
+
+// jidErr should be passed a bad JID. It is used to extract the internal error
+// returned by the JID package so that it can be compared against parse errors
+// that should return either the error from JID parsing, or a new error that
+// wraps it.
+// If the provided JID would not result in an error, jidErr panics to avoid
+// regressions where the tests aren't actually comparing the error we expected.
+func jidErr(addr string) error {
+	_, err := jid.Parse(addr)
+	if err == nil {
+		panic("test requires bad data, but no error was encountered parsing JID")
+	}
+	return err
+}


### PR DESCRIPTION
Implements a parser for XMPP IRIs (see [RFC 3987]) and URIs ([RFC 3986]) as defined in [RFC 5122]. Because it piggybacks on [`net/url`], it may make a handful of invalid assumptions but it should parse most common XMPP IRI's. It also needs a lot of work on the efficiency front to prevent having to escape and unescape repeatedly.

[RFC 3986]: https://tools.ietf.org/html/rfc3986
[RFC 3987]: https://tools.ietf.org/html/rfc3987
[RFC 5122]: https://tools.ietf.org/html/rfc5122
[`net/url`]: https://golang.org/pkg/net/url/