### PR TITLE
all: update the code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,76 +2,127 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer at `codeofconduct@mellium.im`. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an
-incident.  Further details of specific enforcement policies may be posted
-separately.
+reported to the community leaders responsible for enforcement at
+[`codeofconduct@mellium.im`]. All complaints will be reviewed and investigated
+promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[`codeofconduct@mellium.im`]: mailto:codeofconduct@mellium.im

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,74 @@
 # Contributing
 
-Bugs and feature requests can be started by opening an [issue][issues].
+## Issues
 
-If you want to contribute a patch or pull request, make sure you do the
-following first:
+Bugs and feature requests can be started by opening an [issue][issues] (unless
+it is a sensitive security issue, in which case keep reading).
+Always open an issue before creating a pull request unless the PR is trivial,
+all PRs should be linked to an issue and should generally only contain a single
+logical change.
+
+Don't forget to check the issue tracker ([including closed issues]) and [pull
+requests] for existing issues and changes before you start work.
+Once you file an issue or find an existing issue, make sure to mention that
+you're working on the problem and outline your plans so that someone else
+doesn't duplicate your work.
+
+If you're not sure where to begin, grab any of the issues labeled
+[`starter`], and if you need help with any of this, don't be afraid to
+ask!
+
+Security sensitive issues should be reported directly to the project maintainer
+by emailing [`security@mellium.im`].
+
+
+## Creating Patches
+
+When you create your commit, be sure to follow convention for the commit message
+and code formatting.
 
   - Format all code with `go fmt`
   - Write documentation comments for any new public identifiers
   - Write tests for your code
   - Follow Go best practices
+  - Write a detailed commit message
+  - Submit a pull request and wait for review
 
-If you're not sure where to begin, grab any of the issues labeled
-[`starter`][starter], and if you need help with any of this, don't be afraid to
-ask!
+Commit messages should start with the name of the Go package being modified, or
+the string "all" if it affects the entire package, followed by a colon.
+The rest of the first line should be a short description of how it modifies the
+project, for example, the following is a good first line for a commit message:
+
+    dial: fix flaky tests
+
+After the first line should be a blank line, followed by a paragraph or so
+describing the change in more detail.
+This provides context for the commit and should be written in full sentences.
+Do not use Markdown, HTML, or other formatting in your commit messages.
+You may also include benchmarks and other data that showcases why your commit
+should be merged, the Go [benchstat] tool may be helpful for this.
+
+For example, a good full commit message might be:
+
+    dial: fix flaky tests
+
+    Previously a DNS request might have been made for A or AAAA records
+    depending on what networks were available. Tests expected AAAA requests
+    so they would fail on machines that only had IPv4 networking.
+
+
+## Pull Requests
+
+Once your pull request is submitted, you will hear back from a maintainer within
+5 days.
+If you haven't heard back by then, feel free to ping the PR to move it back to
+the top of peoples inboxes.
+
+To update an existing pull request please add more commits on top of the first
+commit so that a reviewer can tell what changed between patches.
+Once your change is accepted your reviewer may ask you to rebase your branch
+on top of the base branch and squash it into a single commit that can be merged,
+or they may handle this for you.
 
 
 ## License
@@ -26,5 +82,9 @@ conditions.
 
 
 [issues]: https://github.com/mellium/xmpp/issues
-[starter]: https://github.com/mellium/xmpp/labels/starter
+[including closed issues]: https://github.com/mellium/xmpp/issues?q=is%3Aissue
+[pull requests]: https://github.com/mellium/xmpp/pulls?q=is%3Apr
+[`starter`]: https://github.com/mellium/xmpp/labels/starter
+[`security@mellium.im`]: mailto:security@mellium.im
+[benchstat]: https://godoc.org/golang.org/x/perf/cmd/benchstat
 [LICENSE]: ./LICENSE


### PR DESCRIPTION
This updates the code of conduct to be based on version 2.0 of the
Contributor Covenant
(https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).