### PR TITLE
mux: add IQ matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- mux: ability to route by IQ payload
 - uri: new package for parsing XMPP URI's and IRI's
 
 

--- a/mux/iq.go
+++ b/mux/iq.go
@@ -1,0 +1,255 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package mux
+
+import (
+	"encoding/xml"
+
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp/internal/ns"
+	"mellium.im/xmpp/jid"
+	"mellium.im/xmpp/stanza"
+)
+
+// IQHandler responds to an IQ stanza.
+type IQHandler interface {
+	HandleIQ(iq stanza.IQ, t xmlstream.TokenReadEncoder, start *xml.StartElement) error
+}
+
+// The IQHandlerFunc type is an adapter to allow the use of ordinary functions
+// as IQ handlers. If f is a function with the appropriate signature,
+// IQHandlerFunc(f) is an IQHandler that calls f.
+type IQHandlerFunc func(iq stanza.IQ, t xmlstream.TokenReadEncoder, start *xml.StartElement) error
+
+// HandleIQ calls f(iq, t, start).
+func (f IQHandlerFunc) HandleIQ(iq stanza.IQ, t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
+	return f(iq, t, start)
+}
+
+type patternKey struct {
+	xml.Name
+	Type stanza.IQType
+}
+
+// IQMux is an XMPP multiplexer meant for handling IQ payloads.
+//
+// IQs are matched by the type and the XML name of their first child element (if
+// any).
+// If either the namespace or the localname is left off, any namespace or
+// localname will be matched.
+// Full XML names take precedence, followed by wildcard localnames, followed by
+// wildcard namespaces.
+//
+// Unlike get and set type IQs, result IQs may have no child element, and error
+// IQs may have more than one child element.
+// Because of this it is normally adviseable to register handlers for type Error
+// without any filter on the child element since we cannot guarantee what child
+// token will come first and be matched against.
+// Similarly, for IQs of type result, it is important to note that the start
+// element passed to the handler may be nil, meaning that there is no child
+// element.
+type IQMux struct {
+	patterns map[patternKey]IQHandler
+}
+
+// NewIQMux allocates and returns a new IQMux.
+func NewIQMux(opt ...IQOption) *IQMux {
+	m := &IQMux{}
+	for _, o := range opt {
+		o(m)
+	}
+	return m
+}
+
+// Handler returns the handler to use for an IQ payload with the given name and
+// type.
+// If no handler exists, a default handler is returned (h is always non-nil).
+func (m *IQMux) Handler(iqType stanza.IQType, name xml.Name) (h IQHandler, ok bool) {
+	pattern := patternKey{Name: name, Type: iqType}
+	h = m.patterns[pattern]
+	if h != nil {
+		return h, true
+	}
+
+	n := name
+	n.Space = ""
+	pattern.Name = n
+	h = m.patterns[pattern]
+	if h != nil {
+		return h, true
+	}
+
+	n = name
+	n.Local = ""
+	pattern.Name = n
+	h = m.patterns[pattern]
+	if h != nil {
+		return h, true
+	}
+
+	pattern.Name = xml.Name{}
+	h = m.patterns[pattern]
+	if h != nil {
+		return h, true
+	}
+
+	return IQHandlerFunc(iqFallback), false
+}
+
+func getPayload(t xmlstream.TokenReadEncoder, start *xml.StartElement) (stanza.IQ, *xml.StartElement, error) {
+	iq, err := newIQFromStart(start)
+	if err != nil {
+		return iq, nil, err
+	}
+
+	tok, err := t.Token()
+	if err != nil {
+		return iq, nil, err
+	}
+	// If this is a result type IQ (or a malformed IQ) there may be no payload, so
+	// make sure start is nil.
+	payloadStart, ok := tok.(xml.StartElement)
+	start = &payloadStart
+	if !ok {
+		start = nil
+	}
+	return iq, start, nil
+}
+
+// HandleXMPP dispatches the IQ to the handler whose pattern most closely
+// matches start.Name.
+func (m *IQMux) HandleXMPP(t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
+	iq, start, err := getPayload(t, start)
+	if err != nil {
+		return err
+	}
+
+	h, _ := m.Handler(iq.Type, start.Name)
+	return h.HandleIQ(iq, t, start)
+}
+
+// IQOption configures an IQMux.
+type IQOption func(m *IQMux)
+
+// HandleIQ returns an option that matches the IQ payload by XML name and IQ
+// type.
+// For readability, users may want to use the GetIQ, SetIQ, ErrorIQ, and
+// ResultIQ shortcuts instead.
+//
+// For more details, see the documentation on IQMux.
+func HandleIQ(iqType stanza.IQType, n xml.Name, h IQHandler) IQOption {
+	return func(m *IQMux) {
+		if h == nil {
+			panic("mux: nil handler")
+		}
+		pattern := patternKey{Name: n, Type: iqType}
+		if _, ok := m.patterns[pattern]; ok {
+			panic("mux: multiple registrations for {" + pattern.Space + "}" + pattern.Local)
+		}
+		if m.patterns == nil {
+			m.patterns = make(map[patternKey]IQHandler)
+		}
+		m.patterns[pattern] = h
+	}
+}
+
+// GetIQ is a shortcut for HandleIQ with the type set to "get".
+func GetIQ(n xml.Name, h IQHandler) IQOption {
+	return HandleIQ(stanza.GetIQ, n, h)
+}
+
+// SetIQ is a shortcut for HandleIQ with the type set to "set".
+func SetIQ(n xml.Name, h IQHandler) IQOption {
+	return HandleIQ(stanza.SetIQ, n, h)
+}
+
+// ErrorIQ is a shortcut for HandleIQ with the type set to "error" and a
+// wildcard XML name.
+//
+// This differs from the other IQ types because error IQs may contain one or
+// more child elements and we cannot guarantee the order of child elements and
+// therefore won't know which element to match on.
+// Instead it is normally wise to register a handler for all error type IQs and
+// then skip or handle unnecessary payloads until we find the error itself.
+func ErrorIQ(h IQHandler) IQOption {
+	return HandleIQ(stanza.ErrorIQ, xml.Name{}, h)
+}
+
+// ResultIQ is a shortcut for HandleIQ with the type set to "result".
+//
+// Unlike IQs of type get, set, and error, result type IQs may or may not
+// contain a payload.
+// Because of this it is important to check whether the start element is nil in
+// handlers meant to handle result type IQs.
+func ResultIQ(n xml.Name, h IQHandler) IQOption {
+	return HandleIQ(stanza.ResultIQ, n, h)
+}
+
+// HandleIQFunc returns an option that matches the IQ payload by XML name and IQ
+// type.
+func HandleIQFunc(iqType stanza.IQType, n xml.Name, h IQHandlerFunc) IQOption {
+	return HandleIQ(iqType, n, h)
+}
+
+// newIQFromStart takes a start element and returns an IQ.
+func newIQFromStart(start *xml.StartElement) (stanza.IQ, error) {
+	iq := stanza.IQ{}
+	var err error
+	for _, a := range start.Attr {
+		switch a.Name.Local {
+		case "id":
+			if a.Name.Space != "" {
+				continue
+			}
+			iq.ID = a.Value
+		case "to":
+			if a.Name.Space != "" {
+				continue
+			}
+			iq.To, err = jid.Parse(a.Value)
+			if err != nil {
+				return iq, err
+			}
+		case "from":
+			if a.Name.Space != "" {
+				continue
+			}
+			iq.From, err = jid.Parse(a.Value)
+			if err != nil {
+				return iq, err
+			}
+		case "lang":
+			if a.Name.Space != ns.XML {
+				continue
+			}
+			iq.Lang = a.Value
+		case "type":
+			if a.Name.Space != "" {
+				continue
+			}
+			iq.Type = stanza.IQType(a.Value)
+		}
+	}
+	return iq, nil
+}
+
+func iqFallback(iq stanza.IQ, t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
+	if iq.Type == stanza.ErrorIQ {
+		return nil
+	}
+
+	iq.To, iq.From = iq.From, iq.To
+	iq.Type = "error"
+
+	e := stanza.Error{
+		Type:      stanza.Cancel,
+		Condition: stanza.ServiceUnavailable,
+	}
+	_, err := xmlstream.Copy(t, stanza.WrapIQ(
+		iq,
+		e.TokenReader(),
+	))
+	return err
+}

--- a/mux/iq_test.go
+++ b/mux/iq_test.go
@@ -1,0 +1,179 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package mux_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp/internal/xmpptest"
+	"mellium.im/xmpp/mux"
+	"mellium.im/xmpp/stanza"
+)
+
+const exampleNS = "com.example"
+
+var passIQHandler mux.IQHandlerFunc = func(stanza.IQ, xmlstream.TokenReadEncoder, *xml.StartElement) error {
+	return passTest
+}
+
+var failIQHandler mux.IQHandlerFunc = func(stanza.IQ, xmlstream.TokenReadEncoder, *xml.StartElement) error {
+	return errors.New("mux_test: FAILED")
+}
+
+var iqTestCases = [...]struct {
+	m      *mux.IQMux
+	p      xml.Name
+	iqType stanza.IQType
+}{
+	0: {
+		// Exact match handler should be selected if available.
+		m: mux.NewIQMux(
+			mux.HandleIQ(stanza.GetIQ, xml.Name{Local: "a", Space: exampleNS}, failIQHandler),
+			mux.HandleIQ(stanza.GetIQ, xml.Name{Local: "test", Space: "b"}, failIQHandler),
+			mux.HandleIQFunc(stanza.GetIQ, xml.Name{Local: "test", Space: exampleNS}, passIQHandler),
+		),
+		p: xml.Name{Local: "test", Space: exampleNS},
+	},
+	1: {
+		// If no exact match is available, fallback to the namespace wildcard
+		// handler.
+		m: mux.NewIQMux(
+			mux.HandleIQ(stanza.GetIQ, xml.Name{Local: "test", Space: ""}, passIQHandler),
+			mux.HandleIQ(stanza.GetIQ, xml.Name{Local: "", Space: exampleNS}, failIQHandler),
+		),
+		p: xml.Name{Local: "test", Space: exampleNS},
+	},
+	2: {
+		// If no exact match or namespace handler is available, fallback local name
+		// handler.
+		m: mux.NewIQMux(
+			mux.HandleIQ(stanza.GetIQ, xml.Name{Local: "", Space: exampleNS}, passIQHandler),
+		),
+		p: xml.Name{Local: "test", Space: exampleNS},
+	},
+	3: {
+		// If no exact match or localname/namespace wildcard is available, fallback
+		// to just matching on type alone.
+		m: mux.NewIQMux(
+			mux.ResultIQ(xml.Name{Local: "test", Space: exampleNS}, failIQHandler),
+			mux.ErrorIQ(passIQHandler),
+		),
+		p:      xml.Name{Local: "test", Space: exampleNS},
+		iqType: stanza.ErrorIQ,
+	},
+	4: {
+		// IQs must be routed correctly by type.
+		m: mux.NewIQMux(
+			mux.GetIQ(xml.Name{Local: "test", Space: exampleNS}, failIQHandler),
+			mux.SetIQ(xml.Name{Local: "test", Space: exampleNS}, failIQHandler),
+			mux.ResultIQ(xml.Name{Local: "test", Space: exampleNS}, passIQHandler),
+			mux.ErrorIQ(passIQHandler),
+		),
+		p:      xml.Name{Local: "test", Space: exampleNS},
+		iqType: stanza.ResultIQ,
+	},
+}
+
+func TestIQMux(t *testing.T) {
+	for i, tc := range iqTestCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			iqType := stanza.GetIQ
+			if tc.iqType != "" {
+				iqType = tc.iqType
+			}
+			err := tc.m.HandleXMPP(
+				testReadEncoder{xmlstream.Wrap(nil, xml.StartElement{Name: tc.p})},
+				&xml.StartElement{Name: xml.Name{Local: "iq"}, Attr: []xml.Attr{{Name: xml.Name{Local: "type"}, Value: string(iqType)}}},
+			)
+			if err != passTest {
+				t.Fatalf("unexpected error: `%v'", err)
+			}
+		})
+	}
+}
+
+type testReadEncoder struct {
+	xml.TokenReader
+}
+
+func (testReadEncoder) EncodeToken(t xml.Token) error { return nil }
+
+func (testReadEncoder) EncodeElement(interface{}, xml.StartElement) error {
+	panic("unexpected EncodeElement")
+}
+
+func (testReadEncoder) Encode(interface{}) error { panic("unexpected Encode") }
+
+func TestIQFallback(t *testing.T) {
+	buf := &bytes.Buffer{}
+	rw := struct {
+		io.Reader
+		io.Writer
+	}{
+		Reader: strings.NewReader(`<iq to="romeo@example.com" from="juliet@example.com" id="123"><test/></iq>`),
+		Writer: buf,
+	}
+	s := xmpptest.NewSession(0, rw)
+
+	r := s.TokenReader()
+	defer r.Close()
+	tok, err := r.Token()
+	if err != nil {
+		t.Fatalf("Bad start token read: `%v'", err)
+	}
+	start := tok.(xml.StartElement)
+	w := s.TokenWriter()
+	defer w.Close()
+	err = mux.NewIQMux().HandleXMPP(testEncoder{
+		TokenReader: r,
+		TokenWriter: w,
+	}, &start)
+	if err != nil {
+		t.Errorf("Unexpected error: `%v'", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Errorf("Unexpected error flushing token writer: %q", err)
+	}
+
+	const expected = `<iq type="error" to="juliet@example.com" from="romeo@example.com" id="123"><error type="cancel"><service-unavailable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"></service-unavailable></error></iq>`
+	if buf.String() != expected {
+		t.Errorf("Bad output:\nwant=`%v'\n got=`%v'", expected, buf.String())
+	}
+}
+
+func TestNilIQHandlerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected a panic when trying to register a nil IQ handler")
+		}
+	}()
+	mux.NewIQMux(mux.GetIQ(xml.Name{}, nil))
+}
+
+func TestIdenticalIQHandlerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected a panic when trying to register a duplicate IQ handler")
+		}
+	}()
+	mux.NewIQMux(
+		mux.GetIQ(xml.Name{Space: "space", Local: "local"}, failIQHandler),
+		mux.GetIQ(xml.Name{Space: "space", Local: "local"}, failIQHandler),
+	)
+}
+
+func TestLazyIQMuxMapInitialization(t *testing.T) {
+	m := &mux.IQMux{}
+
+	// This will panic if the map isn't initialized lazily.
+	mux.GetIQ(xml.Name{}, failIQHandler)(m)
+}


### PR DESCRIPTION
mux: add IQ matcher
    
Adding a separate IQ muxer to the mux package will allow us to easily
match based on the payload of an IQ without requiring special handling
in the standard muxer,

Fixes #18
