### PR TITLE
stanza: add API for easily replying to IQs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - mux: ability to route by IQ payload
 - uri: new package for parsing XMPP URI's and IRI's
+- stanza: API to simplify replying to IQs
 
 
 ### Fixed

--- a/stanza/iq.go
+++ b/stanza/iq.go
@@ -58,6 +58,18 @@ type IQ struct {
 	Type    IQType   `xml:"type,attr"`
 }
 
+// Result returns a token reader that wraps the first element from payload in an
+// IQ stanza with the to and from attributes switched and the type set to
+// ResultIQ.
+func (iq IQ) Result(payload xml.TokenReader) xml.TokenReader {
+	return WrapIQ(IQ{
+		ID:   iq.ID,
+		To:   iq.From,
+		From: iq.To,
+		Type: ResultIQ,
+	}, payload)
+}
+
 // IQType is the type of an IQ stanza.
 // It should normally be one of the constants defined in this package.
 type IQType string

--- a/stanza/iq_test.go
+++ b/stanza/iq_test.go
@@ -116,3 +116,30 @@ func TestUnmarshalIQTypeAttr(t *testing.T) {
 		})
 	}
 }
+
+func TestIQResult(t *testing.T) {
+	iq := stanza.IQ{
+		ID:   "123",
+		To:   jid.MustParse("to@example.net"),
+		From: jid.MustParse("from@example.net"),
+		Type: stanza.SetIQ,
+	}
+	reply := iq.Result(xmlstream.Wrap(nil, xml.StartElement{Name: xml.Name{Local: "foo"}}))
+
+	var b strings.Builder
+	e := xml.NewEncoder(&b)
+	_, err := xmlstream.Copy(e, reply)
+	if err != nil {
+		t.Fatalf("error copying tokens: %v", err)
+	}
+	err = e.Flush()
+	if err != nil {
+		t.Fatalf("error flushing encoder: %v", err)
+	}
+
+	const expected = `<iq type="result" to="from@example.net" from="to@example.net" id="123"><foo></foo></iq>`
+	out := b.String()
+	if out != expected {
+		t.Errorf("want=%q, got=%q", expected, out)
+	}
+}


### PR DESCRIPTION
Previously the user had to do the repetative task of switching the
to/from attributes and changing the type.  While this isn't a lot of
extra work, it has to be done every time you want to reply to an IQ.
Instead it makes sense to have an easy way to simply reply to the IQ
without making an explicit copy or modifying it and without having to
jump through extra hoops.