### PR TITLE
Namespace fixes

### DIFF
--- a/internal/xmpptest/session.go
+++ b/internal/xmpptest/session.go
@@ -8,23 +8,32 @@ package xmpptest // import "mellium.im/xmpp/internal/xmpptest"
 import (
 	"context"
 	"io"
+	"strings"
 
 	"mellium.im/xmpp"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/jid"
+	"mellium.im/xmpp/stream"
 )
 
 // NopNegotiator marks the state as ready (by returning state|xmpp.Ready) and
-// does not actually transmit any data over the wire or perform any other
-// session negotiation.
+// pops the first token (likely <stream:stream>) but does not perform any
+// validation on the token, transmit any data over the wire, or perform any
+// other session negotiation.
 func NopNegotiator(state xmpp.SessionState) xmpp.Negotiator {
-	return func(_ context.Context, _ *xmpp.Session, _ interface{}) (xmpp.SessionState, io.ReadWriter, interface{}, error) {
-		return state | xmpp.Ready, nil, nil, nil
+	return func(ctx context.Context, s *xmpp.Session, data interface{}) (xmpp.SessionState, io.ReadWriter, interface{}, error) {
+		// Pop the stream start token.
+		rc := s.TokenReader()
+		defer rc.Close()
+
+		_, err := rc.Token()
+		return state | xmpp.Ready, nil, nil, err
 	}
 }
 
-// NewSession returns a new XMPP session with the state bits set to
-// state|xmpp.Ready, the origin JID set to "test@example.net" and the location
-// JID set to "example.net".
+// NewSession returns a new client-to-client XMPP session with the state bits
+// set to state|xmpp.Ready, the origin JID set to "test@example.net" and the
+// location JID set to "example.net".
 //
 // NewSession panics on error for ease of use in testing, where a panic is
 // acceptable.
@@ -33,7 +42,19 @@ func NewSession(state xmpp.SessionState, rw io.ReadWriter) *xmpp.Session {
 	origin := jid.MustParse("test@example.net")
 
 	s, err := xmpp.NegotiateSession(
-		context.Background(), location, origin, rw, false,
+		context.Background(), location, origin,
+		struct {
+			io.Reader
+			io.Writer
+		}{
+			Reader: io.MultiReader(
+				strings.NewReader(`<stream:stream xmlns="`+ns.Client+`" xmlns:stream="`+stream.NS+`">`),
+				rw,
+				strings.NewReader(`</stream:stream>`),
+			),
+			Writer: rw,
+		},
+		false,
 		NopNegotiator(state),
 	)
 	if err != nil {

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -70,10 +70,7 @@ func (m *ServeMux) Handler(name xml.Name) (h xmpp.Handler, ok bool) {
 		return h, true
 	}
 
-	// Route stanzas.
-	// TODO: Fix the session so that a default namespace is always declared and
-	// then remove the check for an empty namespace.
-	if name.Space == "" || name.Space == ns.Client || name.Space == ns.Server {
+	if name.Space == ns.Client || name.Space == ns.Server {
 		switch name.Local {
 		case "iq":
 			return xmpp.HandlerFunc(m.iqRouter), true

--- a/ping/ping_test.go
+++ b/ping/ping_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"mellium.im/xmlstream"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/mux"
@@ -81,6 +82,7 @@ func TestRoundTrip(t *testing.T) {
 	}
 
 	d := xml.NewDecoder(strings.NewReader(req.String()))
+	d.DefaultSpace = ns.Client
 	tok, _ := d.Token()
 	start := tok.(xml.StartElement)
 	var b strings.Builder

--- a/session.go
+++ b/session.go
@@ -444,7 +444,7 @@ func (rw *responseChecker) EncodeToken(t xml.Token) error {
 	switch tok := t.(type) {
 	case xml.StartElement:
 		_, id := attr.Get(tok.Attr, "id")
-		if rw.level < 1 && isIQ(tok.Name) && id == rw.id && !iqNeedsResp(tok.Attr) {
+		if rw.level < 1 && isIQEmptySpace(tok.Name) && id == rw.id && !iqNeedsResp(tok.Attr) {
 			rw.wroteResp = true
 		}
 		rw.level++
@@ -712,12 +712,16 @@ func iqNeedsResp(attrs []xml.Attr) bool {
 }
 
 func isIQ(name xml.Name) bool {
+	return name.Local == "iq" && (name.Space == ns.Client || name.Space == ns.Server)
+}
+
+func isIQEmptySpace(name xml.Name) bool {
 	return name.Local == "iq" && (name.Space == "" || name.Space == ns.Client || name.Space == ns.Server)
 }
 
 func isStanza(name xml.Name) bool {
 	return (name.Local == "iq" || name.Local == "message" || name.Local == "presence") &&
-		(name.Space == "" || name.Space == ns.Client || name.Space == ns.Server)
+		(name.Space == ns.Client || name.Space == ns.Server)
 }
 
 // SendIQ is like Send except that it returns an error if the first token read
@@ -750,7 +754,7 @@ func (s *Session) SendIQ(ctx context.Context, r xml.TokenReader) (xmlstream.Toke
 	if !ok {
 		return nil, fmt.Errorf("expected IQ start element, got %T", tok)
 	}
-	if !isIQ(start.Name) {
+	if !isIQEmptySpace(start.Name) {
 		return nil, fmt.Errorf("expected start element to be an IQ")
 	}
 

--- a/xtime/time_test.go
+++ b/xtime/time_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"mellium.im/xmlstream"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/mux"
@@ -52,6 +53,7 @@ func TestRoundTrip(t *testing.T) {
 	}
 
 	d := xml.NewDecoder(strings.NewReader(req.String()))
+	d.DefaultSpace = ns.Server
 	tok, _ := d.Token()
 	start := tok.(xml.StartElement)
 	var b strings.Builder


### PR DESCRIPTION
In an effort to remove the special cases around checking for stanzas that involve empty namespaces, I am experimenting with automatically wrapping testing sessions in a root element that sets a namespace and then using stricter validation everywhere else.