### PR TITLE
Add experimental integration test packages

### DIFF
--- a/.builds/integration.yml
+++ b/.builds/integration.yml
@@ -1,0 +1,15 @@
+image: freebsd/latest
+packages:
+  - go
+  - openssl
+  - prosody
+  - ejabberd
+sources:
+  - https://github.com/mellium/xmpp
+tasks:
+  - setup: |
+      go version
+      go env
+  - stable: |
+      cd xmpp/
+      go test -v -tags "integration" ./...

--- a/design/42_integration_testing.md
+++ b/design/42_integration_testing.md
@@ -1,7 +1,7 @@
 # Proposal: Create integration testing package
 
 **Author(s):** Sam Whited  
-**Last updated:** 2020-04-05  
+**Last updated:** 2020-04-28  
 **Discussion:** https://mellium.im/issue/42
 
 
@@ -40,9 +40,8 @@ with various config files and other resources and then run commands such as
 
 ## Proposal
 
-The proposed API adds three new types, seven functions, and three methods that
-would have to be maintained if we reached version 1.0 and began observing the Go
-compatibility promise:
+The proposed API adds three new types, seven functions, and three methods to an
+internal package that does not have to be covered by the compatibility promise:
 
 
 ```

--- a/internal/integration/ejabberd/config.go
+++ b/internal/integration/ejabberd/config.go
@@ -1,0 +1,110 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package ejabberd
+
+import (
+	"path/filepath"
+	"text/template"
+)
+
+// Config contains options that can be written to a Prosody config file.
+type Config struct {
+	VHosts []string
+}
+
+const inetrc = `{lookup,["file","native"]}.
+{host,{127,0,0,1}, ["localhost","hostalias"]}.
+{file, resolv, "/etc/resolv.conf"}.`
+
+const cfgBase = `{{- if .VHosts }}
+hosts:
+{{- range .VHosts }}
+  - {{.}}
+{{- end }}
+
+certfiles:
+{{- range .VHosts }}
+ - {{ filepathJoin $.ConfigDir . }}.crt
+ - {{ filepathJoin $.ConfigDir . }}.key
+{{- end }}
+{{- end }}
+
+loglevel: info
+
+listen:
+  -
+    port: 5222
+    ip: "::1"
+    module: ejabberd_c2s
+    max_stanza_size: 262144
+    shaper: c2s_shaper
+    access: c2s
+    starttls_required: true
+
+s2s_use_starttls: optional
+
+modules:
+  mod_adhoc: {}
+  mod_admin_extra: {}
+  mod_announce:
+    access: announce
+  mod_avatar: {}
+  mod_blocking: {}
+  mod_bosh: {}
+  mod_caps: {}
+  mod_carboncopy: {}
+  mod_client_state: {}
+  mod_configure: {}
+  mod_disco: {}
+  mod_fail2ban: {}
+  mod_http_api: {}
+  mod_http_upload:
+    put_url: https://@HOST@:5443/upload
+  mod_last: {}
+  mod_mam:
+    assume_mam_usage: true
+    default: always
+  mod_muc:
+    access:
+      - allow
+    access_admin:
+      - allow: admin
+    access_create: muc_create
+    access_persistent: muc_create
+    access_mam:
+      - allow
+    default_room_options:
+      mam: true
+  mod_muc_admin: {}
+  mod_offline:
+    access_max_user_messages: max_user_offline_messages
+  mod_ping: {}
+  mod_privacy: {}
+  mod_private: {}
+  mod_pubsub:
+    access_createnode: pubsub_createnode
+    plugins:
+      - flat
+      - pep
+    force_node_config:
+      ## Avoid buggy clients to make their bookmarks public
+      storage:bookmarks:
+        access_model: whitelist
+  mod_register:
+    ip_access: trusted_network
+  mod_roster:
+    versioning: true
+  mod_s2s_dialback: {}
+  mod_shared_roster: {}
+  mod_stream_mgmt:
+    resend_on_timeout: if_offline
+  mod_vcard: {}
+  mod_vcard_xupdate: {}
+  mod_version:
+    show_os: false`
+
+var cfgTmpl = template.Must(template.New("cfg").Funcs(template.FuncMap{
+	"filepathJoin": filepath.Join,
+}).Parse(cfgBase))

--- a/internal/integration/ejabberd/ejabberd.go
+++ b/internal/integration/ejabberd/ejabberd.go
@@ -1,0 +1,96 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+// Package ejabberd facilitates integration testing against Ejabberd.
+package ejabberd // import "mellium.im/xmpp/internal/integration/ejabberd"
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"mellium.im/xmpp/internal/integration"
+)
+
+const (
+	cfgFileName = "ejabberd.yml"
+	configFlag  = "--config-dir"
+	cmdName     = "ejabberdctl"
+)
+
+// New creates a new, unstarted, ejabberd daemon.
+//
+// The provided context is used to kill the process (by calling os.Process.Kill)
+// if the context becomes done before the command completes on its own.
+func New(ctx context.Context, opts ...integration.Option) (*integration.Cmd, error) {
+	opts = append(opts, foreground)
+	cmd, err := integration.New(
+		ctx, cmdName,
+		opts...,
+	)
+	return cmd, err
+}
+
+// ConfigFile is an option that can be used to write a temporary Ejabberd config
+// file.
+func ConfigFile(cfg Config) integration.Option {
+	return func(cmd *integration.Cmd) error {
+		err := integration.TempFile(cfgFileName, func(cmd *integration.Cmd, w io.Writer) error {
+			return cfgTmpl.Execute(w, struct {
+				Config
+				ConfigDir string
+			}{
+				Config:    cfg,
+				ConfigDir: cmd.ConfigDir(),
+			})
+		})(cmd)
+		if err != nil {
+			return err
+		}
+		err = integration.Args(configFlag, cmd.ConfigDir())(cmd)
+		if err != nil {
+			return err
+		}
+		err = integration.Args("--logs", cmd.ConfigDir())(cmd)
+		if err != nil {
+			return err
+		}
+		return integration.Args("--spool", cmd.ConfigDir())(cmd)
+	}
+}
+
+func defaultConfig(cmd *integration.Cmd) error {
+	for _, arg := range cmd.Cmd.Args {
+		if arg == configFlag {
+			return nil
+		}
+	}
+
+	// The config file didn't exist, so create a default config.
+	return ConfigFile(Config{
+		VHosts: []string{"localhost"},
+	})(cmd)
+}
+
+func inetrcFile(cmd *integration.Cmd) error {
+	return integration.TempFile("inetrc", func(_ *integration.Cmd, w io.Writer) error {
+		_, err := fmt.Fprint(w, inetrc)
+		return err
+	})(cmd)
+}
+
+func foreground(cmd *integration.Cmd) error {
+	return integration.Args("foreground")(cmd)
+}
+
+// Test starts an Ejabberd instance and returns a function that runs f as a
+// subtest using t.Run.
+// Multiple calls to the returned function will result in uniquely named
+// subtests.
+// When all subtests have completed, the daemon is stopped.
+func Test(ctx context.Context, t *testing.T, opts ...integration.Option) integration.SubtestRunner {
+	opts = append(opts, defaultConfig, inetrcFile, foreground)
+	return integration.Test(ctx, cmdName, t, opts...)
+}

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -1,0 +1,300 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+// Package integration contains helpers for integration testing.
+//
+// Normally users writing integration tests should not use this package
+// directly, instead they should use the packges in subdirectories of this
+// package.
+package integration // import "mellium.im/xmpp/internal/integration"
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"mellium.im/xmpp"
+	"mellium.im/xmpp/dial"
+	"mellium.im/xmpp/jid"
+)
+
+// Cmd is an external command being prepared or run.
+//
+// A Cmd cannot be reused after calling its Run, Output or CombinedOutput
+// methods.
+type Cmd struct {
+	*exec.Cmd
+
+	name    string
+	cfgDir  string
+	kill    context.CancelFunc
+	cfgF    []func() error
+	in, out *testWriter
+}
+
+// New creates a new, unstarted, command.
+//
+// The provided context is used to kill the process (by calling os.Process.Kill)
+// if the context becomes done before the command completes on its own.
+func New(ctx context.Context, name string, opts ...Option) (*Cmd, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	cmd := &Cmd{
+		Cmd:  exec.CommandContext(ctx, name),
+		name: name,
+		kill: cancel,
+	}
+	for _, opt := range opts {
+		opt(cmd)
+	}
+	for _, f := range cmd.cfgF {
+		err := f()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return cmd, nil
+}
+
+// ConfigDir returns the temporary directory used to store config files.
+func (cmd *Cmd) ConfigDir() string {
+	return cmd.cfgDir
+}
+
+// Close kills the command if it is still running and cleans up any temporary
+// resources that were created.
+func (cmd *Cmd) Close() error {
+	defer cmd.kill()
+
+	if cmd.cfgDir != "" {
+		err := os.RemoveAll(cmd.cfgDir)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Dial attempts to connect to the server by dialing localhost and then
+// negotiating a stream with the location set to the domainpart of j and the
+// origin set to j.
+func (cmd *Cmd) Dial(ctx context.Context, j jid.JID, t *testing.T, features ...xmpp.StreamFeature) (*xmpp.Session, error) {
+	dialer := dial.Dialer{
+		NoLookup: true,
+		NoTLS:    true,
+	}
+	conn, err := dialer.Dial(ctx, "tcp", jid.MustParse("localhost"))
+	if err != nil {
+		return nil, fmt.Errorf("error dialing %s: %w", j, err)
+	}
+	negotiator := xmpp.NewNegotiator(xmpp.StreamConfig{
+		Features: features,
+		TeeIn:    cmd.in,
+		TeeOut:   cmd.out,
+	})
+	session, err := xmpp.NegotiateSession(
+		ctx,
+		j.Domain(),
+		j,
+		conn,
+		false,
+		negotiator,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error establishing session: %w", err)
+	}
+	return session, nil
+}
+
+// Option is used to configure a Cmd.
+type Option func(cmd *Cmd) error
+
+// Args sets additional command line args to be passed to the command.
+func Args(f ...string) Option {
+	return func(cmd *Cmd) error {
+		cmd.Cmd.Args = append(cmd.Args, f...)
+		return nil
+	}
+}
+
+// Cert creates a private key and certificate with the given name.
+func Cert(name string) Option {
+	return func(cmd *Cmd) error {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return err
+		}
+		err = TempFile(name+".key", func(_ *Cmd, w io.Writer) error {
+			return pem.Encode(w, &pem.Block{
+				Type:  "RSA PRIVATE KEY",
+				Bytes: x509.MarshalPKCS1PrivateKey(key),
+			})
+		})(cmd)
+		if err != nil {
+			return err
+		}
+		return TempFile(name+".crt", func(_ *Cmd, w io.Writer) error {
+			crt := &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				NotBefore:    time.Now(),
+				NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+				DNSNames:     []string{filepath.Base(name)},
+			}
+			cert, err := x509.CreateCertificate(rand.Reader, crt, crt, key.Public(), key)
+			if err != nil {
+				return err
+			}
+			return pem.Encode(w, &pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: cert,
+			})
+		})(cmd)
+	}
+}
+
+// TempFile creates a file in the commands temporary working directory.
+// After all configuration is complete it then calls f to populate the config
+// files.
+func TempFile(cfgFileName string, f func(*Cmd, io.Writer) error) Option {
+	return func(cmd *Cmd) (err error) {
+		if cmd.cfgDir == "" {
+			cmd.cfgDir, err = ioutil.TempDir("", cmd.name)
+			if err != nil {
+				return err
+			}
+		}
+		dir := filepath.Dir(cfgFileName)
+		if dir != "" && dir != "." && dir != "/" && dir != ".." {
+			err = os.MkdirAll(filepath.Join(cmd.cfgDir, dir), 0700)
+			if err != nil {
+				return err
+			}
+		}
+
+		cmd.cfgF = append(cmd.cfgF, func() error {
+			cfgFilePath := filepath.Join(cmd.cfgDir, cfgFileName)
+			cfgFile, err := os.Create(cfgFilePath)
+			if err != nil {
+				return err
+			}
+
+			defer cfgFile.Close()
+			return f(cmd, cfgFile)
+		})
+		return nil
+	}
+}
+
+type testWriter struct {
+	sync.Mutex
+	t   *testing.T
+	tag string
+}
+
+func (w *testWriter) Write(p []byte) (int, error) {
+	if w == nil {
+		return len(p), nil
+	}
+	w.Lock()
+	defer w.Unlock()
+
+	if w.t != nil {
+		w.t.Logf("%s%s", w.tag, p)
+	}
+	return len(p), nil
+}
+
+func (w *testWriter) Update(t *testing.T) {
+	if w == nil {
+		return
+	}
+	w.Lock()
+	w.t = t
+	w.Unlock()
+}
+
+// Log configures the command to log output to the current testing.T.
+func Log() Option {
+	return func(cmd *Cmd) error {
+		w := &testWriter{}
+		cmd.Cmd.Stdout = w
+		cmd.Cmd.Stderr = w
+		return nil
+	}
+}
+
+// LogXML configures the command to log sent and received XML to the current
+// testing.T.
+func LogXML() Option {
+	return func(cmd *Cmd) error {
+		cmd.in = &testWriter{tag: "RECV"}
+		cmd.out = &testWriter{tag: "SENT"}
+		return nil
+	}
+}
+
+// Test starts a command and returns a function that runs f as a subtest using
+// t.Run.
+// Multiple calls to the returned function will result in uniquely named
+// subtests.
+// When all subtests have completed, the daemon is stopped.
+func Test(ctx context.Context, name string, t *testing.T, opts ...Option) SubtestRunner {
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	cmd, err := New(ctx, name, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err := cmd.Close()
+		if err != nil {
+			t.Logf("error cleaning up test: %v", err)
+		}
+	})
+
+	if tw, ok := cmd.Cmd.Stdout.(*testWriter); ok {
+		tw.Update(t)
+	}
+	cmd.in.Update(t)
+	cmd.out.Update(t)
+	err = cmd.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = waitPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := -1
+	return func(f func(context.Context, *testing.T, *Cmd)) bool {
+		i++
+		return t.Run(fmt.Sprintf("%s/%d", name, i), func(t *testing.T) {
+			if tw, ok := cmd.Cmd.Stdout.(*testWriter); ok {
+				tw.Update(t)
+			}
+			cmd.in.Update(t)
+			cmd.out.Update(t)
+			f(ctx, t, cmd)
+		})
+	}
+}
+
+// SubtestRunner is the signature of a function that can be used to start
+// subtests.
+type SubtestRunner func(func(context.Context, *testing.T, *Cmd)) bool

--- a/internal/integration/prosody/config.go
+++ b/internal/integration/prosody/config.go
@@ -1,0 +1,80 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package prosody
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// Config contains options that can be written to a Prosody config file.
+type Config struct {
+	Admins []string
+	VHosts []string
+}
+
+const cfgBase = `daemonize = false
+pidfile = "{{ filepathJoin .ConfigDir "prosody.pid" }}"
+admins = { {{ joinQuote .Admins }} }
+
+modules_enabled = {
+
+	-- Generally required
+		"roster"; -- Allow users to have a roster. Recommended ;)
+		"saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
+		"tls"; -- Add support for secure TLS on c2s/s2s connections
+		"dialback"; -- s2s dialback support
+		"disco"; -- Service discovery
+
+	-- Not essential, but recommended
+		"carbons"; -- Keep multiple clients in sync
+		"pep"; -- Enables users to publish their avatar, mood, activity, playing music and more
+		"private"; -- Private XML storage (for room bookmarks, etc.)
+		"blocklist"; -- Allow users to block communications with other users
+		"vcard4"; -- User profiles (stored in PEP)
+		"vcard_legacy"; -- Conversion between legacy vCard and PEP Avatar, vcard
+
+	-- Nice to have
+		"version"; -- Replies to server version requests
+		"uptime"; -- Report how long server has been running
+		"time"; -- Let others know the time here on this server
+		"ping"; -- Replies to XMPP pings with pongs
+		"register"; -- Allow users to register on this server using a client and change passwords
+
+	-- Admin interfaces
+		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
+}
+
+allow_registration = false
+c2s_require_encryption = true
+s2s_require_encryption = true
+s2s_secure_auth = false
+s2s_insecure_domains = { {{ joinQuote .VHosts }} }
+authentication = "internal_hashed"
+storage = "internal"
+
+log = {
+	"*console";
+}
+
+statistics = "internal"
+certificates = "certs"
+
+{{- range .VHosts }}
+VirtualHost "{{ . }}"
+{{- end }}`
+
+var cfgTmpl = template.Must(template.New("cfg").Funcs(template.FuncMap{
+	"filepathJoin": filepath.Join,
+	"joinQuote": func(s []string) string {
+		s = append(s[:0:0], s...)
+		for i, ss := range s {
+			s[i] = fmt.Sprintf("%q", ss)
+		}
+		return strings.Join(s, ",")
+	},
+}).Parse(cfgBase))

--- a/internal/integration/prosody/prosody.go
+++ b/internal/integration/prosody/prosody.go
@@ -1,0 +1,76 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+// Package prosody facilitates integration testing against Prosody.
+package prosody // import "mellium.im/xmpp/internal/integration/prosody"
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"mellium.im/xmpp/internal/integration"
+)
+
+const (
+	cfgFileName = "prosody.cfg.lua"
+	cmdName     = "prosody"
+	configFlag  = "--config"
+)
+
+// New creates a new, unstarted, ejabberd daemon.
+//
+// The provided context is used to kill the process (by calling os.Process.Kill)
+// if the context becomes done before the command completes on its own.
+func New(ctx context.Context, opts ...integration.Option) (*integration.Cmd, error) {
+	return integration.New(
+		ctx, cmdName,
+		opts...,
+	)
+}
+
+// ConfigFile is an option that can be used to write a temporary Prosody config
+// file.
+func ConfigFile(cfg Config) integration.Option {
+	return func(cmd *integration.Cmd) error {
+		err := integration.TempFile(cfgFileName, func(cmd *integration.Cmd, w io.Writer) error {
+			return cfgTmpl.Execute(w, struct {
+				Config
+				ConfigDir string
+			}{
+				Config:    cfg,
+				ConfigDir: cmd.ConfigDir(),
+			})
+		})(cmd)
+		if err != nil {
+			return err
+		}
+		cfgFilePath := filepath.Join(cmd.ConfigDir(), cfgFileName)
+		return integration.Args(configFlag, cfgFilePath)(cmd)
+	}
+}
+
+func defaultConfig(cmd *integration.Cmd) error {
+	for _, arg := range cmd.Cmd.Args {
+		if arg == configFlag {
+			return nil
+		}
+	}
+
+	// The config file didn't exist, so create a default config.
+	return ConfigFile(Config{
+		VHosts: []string{"localhost"},
+	})(cmd)
+}
+
+// Test starts an Ejabberd instance and returns a function that runs f as a
+// subtest using t.Run.
+// Multiple calls to the returned function will result in uniquely named
+// subtests.
+// When all subtests have completed, the daemon is stopped.
+func Test(ctx context.Context, t *testing.T, opts ...integration.Option) integration.SubtestRunner {
+	opts = append(opts, defaultConfig)
+	return integration.Test(ctx, cmdName, t, opts...)
+}

--- a/internal/integration/waitdial.go
+++ b/internal/integration/waitdial.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package integration
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+func waitPort() error {
+	const socketName = "localhost:5222"
+	connAttempts := 10
+	timeout := time.Second
+	for {
+		if connAttempts--; connAttempts == 0 {
+			return fmt.Errorf("failed to bind to %s", socketName)
+		}
+		time.Sleep(timeout)
+		conn, err := net.DialTimeout("tcp", socketName, timeout)
+		if err != nil {
+			continue
+		}
+		timeout += 500 * time.Millisecond
+		if err = conn.Close(); err != nil {
+			return fmt.Errorf("failed to close probe connection: %w", err)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
This adds three packages, `internal/integration`, `internal/integration/prosody`, and `internal/integration/ejabberd` that can be used to spin up servers with a specific configuration and easily run tests against them. It is likely not yet ready for merge, but I wanted to push up what work I had done to remind me to get back to it one of these weekends and because someone was asking about a related testing issue.

Fixes #42