### PR TITLE
xmpp: check every feature in the list for required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 
+## Unreleased
+
+### Fixed
+
+- xmpp: stream negotiation no longer fails when the only required features
+  cannot yet be negotiated because they depend on optional features
+
+
 ## v0.16.0 — 2020-03-08
 
 ### Breaking


### PR DESCRIPTION
Previously if a required feature in a list of stream features could not
be negotiated (eg. because one of its necessary state bits wasn't set)
it would be skipped over and the stream features list would not be
marked as containing required features. This means that if no feature in
the list was marked as required, we would assume that was the end of
stream negotiation and bail out early. Instead, make sure to always
parse every feature and check if it's required, even if it can't be
negotiated. This way we know that we need to try again and negotiate one
of the required features after negotiating the optional features.

Fixes #47

Signed-off-by: Sam Whited <sam@samwhited.com>