### PR TITLE
disco: Rename GetItems(IQ) to FetchItems(IQ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Breaking
 
 - color: change list of color vision deficiencies from uint8 to a new type
+- disco: rename `GetItems` and `GetItemsIQ` to `FetchItems` and `FetchItemsIQ`
+  to signal that they return an iterator
 
 
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@
 // For more info see https://www.git-scm.com/docs/git-check-mailmap
 
 Sam Whited <sam@samwhited.com>
+Michael Vetter <jubalh@iodoru.org>

--- a/disco/items.go
+++ b/disco/items.go
@@ -112,7 +112,7 @@ func (i *ItemIter) Next() bool {
 		return false
 	}
 	// TODO: set context based on a deadline?
-	i.iter = GetItems(i.ctx, i.current, i.session).iter
+	i.iter = FetchItems(i.ctx, i.current, i.session).iter
 	return i.Next()
 }
 
@@ -140,7 +140,7 @@ func (i *ItemIter) Close() error {
 	return i.iter.Close()
 }
 
-// GetItems discovers a set of items associated with a JID and optional node of
+// FetchItems discovers a set of items associated with a JID and optional node of
 // the provided item.
 // The Name attribute of the query item is ignored.
 // An empty Node means to query the root items for the JID.
@@ -149,13 +149,13 @@ func (i *ItemIter) Close() error {
 // The iterator must be closed before anything else is done on the session.
 // Any errors encountered while creating the iter are deferred until the iter is
 // used.
-func GetItems(ctx context.Context, item Item, s *xmpp.Session) *ItemIter {
-	return GetItemsIQ(ctx, item.Node, stanza.IQ{To: item.JID}, s)
+func FetchItems(ctx context.Context, item Item, s *xmpp.Session) *ItemIter {
+	return FetchItemsIQ(ctx, item.Node, stanza.IQ{To: item.JID}, s)
 }
 
-// GetItemsIQ is like GetItems but it allows you to customize the IQ.
+// FetchItemsIQ is like FetchItems but it allows you to customize the IQ.
 // Changing the type of the provided IQ has no effect.
-func GetItemsIQ(ctx context.Context, node string, iq stanza.IQ, s *xmpp.Session) *ItemIter {
+func FetchItemsIQ(ctx context.Context, node string, iq stanza.IQ, s *xmpp.Session) *ItemIter {
 	if iq.Type != stanza.GetIQ {
 		iq.Type = stanza.GetIQ
 	}
@@ -260,7 +260,7 @@ func walkItem(ctx context.Context, level, itemIdx int, items []Item, s *xmpp.Ses
 }
 
 func appendItems(ctx context.Context, s *xmpp.Session, itemIdx int, items []Item) (i []Item, err error) {
-	iter := GetItems(ctx, items[itemIdx], s)
+	iter := FetchItems(ctx, items[itemIdx], s)
 	defer func() {
 		e := iter.Close()
 		if err == nil {

--- a/disco/items_test.go
+++ b/disco/items_test.go
@@ -18,7 +18,7 @@ import (
 	"mellium.im/xmpp/stanza"
 )
 
-var testGetItems = [...]struct {
+var testFetchItems = [...]struct {
 	node  string
 	items map[string][]disco.Item
 	err   error
@@ -52,12 +52,12 @@ type queryItems struct {
 	Items   []disco.Item `xml:"item"`
 }
 
-func TestGetItems(t *testing.T) {
+func TestFetchItems(t *testing.T) {
 	var IQ = stanza.IQ{
 		ID:   "123",
 		Type: stanza.ResultIQ,
 	}
-	for i, tc := range testGetItems {
+	for i, tc := range testFetchItems {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			cs := xmpptest.NewClientServer(
 				xmpptest.ServerHandlerFunc(func(e xmlstream.TokenReadEncoder, start *xml.StartElement) error {
@@ -78,7 +78,7 @@ func TestGetItems(t *testing.T) {
 					return e.Encode(sendIQ)
 				}),
 			)
-			iter := disco.GetItemsIQ(context.Background(), tc.node, IQ, cs.Client)
+			iter := disco.FetchItemsIQ(context.Background(), tc.node, IQ, cs.Client)
 			items := make([]disco.Item, 0, len(tc.items))
 			for iter.Next() {
 				items = append(items, iter.Item())


### PR DESCRIPTION
Like this we consistently signal that functions with the prefix `Fetch`
return an iterator.

See #116

Signed-off-by: Michael Vetter <jubalh@iodoru.org>