### PR TITLE
all: Add function stanza.Is()

### DIFF
--- a/delay/delay.go
+++ b/delay/delay.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"mellium.im/xmlstream"
-	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/jid"
+	"mellium.im/xmpp/stanza"
 	"mellium.im/xmpp/xtime"
 )
 
@@ -101,16 +101,10 @@ func (d *Delay) UnmarshalXML(decoder *xml.Decoder, start xml.StartElement) error
 	return decoder.Skip()
 }
 
-// TODO: replace when #113 is ready.
-func isStanza(name xml.Name) bool {
-	return (name.Local == "iq" || name.Local == "message" || name.Local == "presence") &&
-		(name.Space == ns.Client || name.Space == ns.Server)
-}
-
 // Stanza inserts a delay into any stanza read through the stream.
 func Stanza(d Delay) xmlstream.Transformer {
 	return xmlstream.InsertFunc(func(start xml.StartElement, level uint64, w xmlstream.TokenWriter) error {
-		if !isStanza(start.Name) || level != 1 {
+		if !stanza.Is(start.Name) || level != 1 {
 			return nil
 		}
 

--- a/mux/option.go
+++ b/mux/option.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 
 	"mellium.im/xmpp"
-	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/stanza"
 )
 
@@ -85,11 +84,6 @@ func PresenceFunc(typ stanza.PresenceType, payload xml.Name, h PresenceHandlerFu
 	return Presence(typ, payload, h)
 }
 
-func isStanza(name xml.Name) bool {
-	return (name.Local == iqStanza || name.Local == msgStanza || name.Local == presStanza) &&
-		(name.Space == "" || name.Space == ns.Client || name.Space == ns.Server)
-}
-
 // Handle returns an option that matches on the provided XML name.
 // If a handler already exists for n when the option is applied, the option
 // panics.
@@ -98,7 +92,7 @@ func Handle(n xml.Name, h xmpp.Handler) Option {
 		if h == nil {
 			panic("mux: nil handler")
 		}
-		if isStanza(n) {
+		if stanza.Is(n) {
 			panic("mux: tried to register stanza handler with Handle, use HandleIQ, HandleMessage, or HandlePresence instead")
 		}
 		if _, ok := m.patterns[n]; ok {

--- a/session.go
+++ b/session.go
@@ -481,7 +481,7 @@ func handleInputStream(s *Session, handler Handler) (err error) {
 	}
 
 	// If this is a stanza, normalize the "from" attribute.
-	if isStanza(start.Name) {
+	if stanza.Is(start.Name) {
 		for i, attr := range start.Attr {
 			if attr.Name.Local == "from" /*&& attr.Name.Space == start.Name.Space*/ {
 				local := s.LocalAddr().Bare().String()
@@ -947,11 +947,6 @@ func isIQ(name xml.Name) bool {
 
 func isIQEmptySpace(name xml.Name) bool {
 	return name.Local == "iq" && (name.Space == "" || name.Space == ns.Client || name.Space == ns.Server)
-}
-
-func isStanza(name xml.Name) bool {
-	return (name.Local == "iq" || name.Local == "message" || name.Local == "presence") &&
-		(name.Space == ns.Client || name.Space == ns.Server)
 }
 
 func isStanzaEmptySpace(name xml.Name) bool {

--- a/stanza/id.go
+++ b/stanza/id.go
@@ -9,7 +9,6 @@ import (
 
 	"mellium.im/xmlstream"
 	"mellium.im/xmpp/internal/attr"
-	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/jid"
 )
 
@@ -66,16 +65,11 @@ func (id OriginID) WriteXML(w xmlstream.TokenWriter) (int, error) {
 	return xmlstream.Copy(w, id.TokenReader())
 }
 
-func isStanza(name xml.Name) bool {
-	return (name.Local == "iq" || name.Local == "message" || name.Local == "presence") &&
-		(name.Space == ns.Client || name.Space == ns.Server)
-}
-
 // AddID returns an transformer that adds a random stanza ID to any stanzas that
 // does not already have one.
 func AddID(by jid.JID) xmlstream.Transformer {
 	return xmlstream.InsertFunc(func(start xml.StartElement, level uint64, w xmlstream.TokenWriter) error {
-		if isStanza(start.Name) && level == 1 {
+		if Is(start.Name) && level == 1 {
 			_, err := ID{
 				ID: attr.RandomLen(idLen),
 				By: by,
@@ -88,7 +82,7 @@ func AddID(by jid.JID) xmlstream.Transformer {
 
 var (
 	addOriginID = xmlstream.InsertFunc(func(start xml.StartElement, level uint64, w xmlstream.TokenWriter) error {
-		if isStanza(start.Name) && level == 1 {
+		if Is(start.Name) && level == 1 {
 			_, err := OriginID{
 				ID: attr.RandomLen(idLen),
 			}.WriteXML(w)

--- a/stanza/stanza.go
+++ b/stanza/stanza.go
@@ -1,0 +1,17 @@
+// Copyright 2016 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package stanza
+
+import (
+	"encoding/xml"
+
+	"mellium.im/xmpp/internal/ns"
+)
+
+// Is tests whether name is a valid stanza based on name and space.
+func Is(name xml.Name) bool {
+	return (name.Local == "iq" || name.Local == "message" || name.Local == "presence") &&
+		(name.Space == ns.Client || name.Space == ns.Server)
+}


### PR DESCRIPTION
Add exported function stanza.Is() which tests an xml.Name for its name
and space. If it is a proper stanza it returns true.
This function was repeatedly defined in several files and is now defined
one time and exported in stanza/stanza.go

Fixes #113