### PR TITLE
xmpp: fix an error in UnmarshalIQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this project will be documented in this file.
   child in the payload
 - styling: pre-block start tokens with no newline had nonsensical formatting
 - xmpp: empty IQ iters no longer return EOF when there is no payload
+- xmpp: `UnmarshalIQ` and `UnmarshalIQElement` no longer return an XML error
+  on responses with no payload
 
 
 [XEP-0045: Multi-User Chat]: https://xmpp.org/extensions/xep-0045.html

--- a/session_iq.go
+++ b/session_iq.go
@@ -201,9 +201,19 @@ func unmarshalIQ(ctx context.Context, iq xml.TokenReader, v interface{}, s *Sess
 	if err != nil {
 		return err
 	}
-	d := xml.NewTokenDecoder(resp)
 	if v == nil {
 		return nil
 	}
-	return d.Decode(v)
+	payload := xmlstream.Inner(resp)
+	d := xml.NewTokenDecoder(payload)
+	startTok, err := d.Token()
+	switch err {
+	case io.EOF:
+		return nil
+	case nil:
+	default:
+		return err
+	}
+	start = startTok.(xml.StartElement)
+	return d.DecodeElement(v, &start)
 }


### PR DESCRIPTION
Previously UnmarshalIQ would fail if there was no payload in the IQ (eg.
an empty IQ result, indicating success). Instead, skip unmarshaling in
this case.

Signed-off-by: Sam Whited <sam@samwhited.com>