### PR TITLE
all: allow handlers to respond to disco#items requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to this project will be documented in this file.
 - commands: new package implementing [XEP-0050: Ad-Hoc Commands]
 - history: implement [XEP-0313: Message Archive Management]
 - muc: new package implementing [XEP-0045: Multi-User Chat] and [XEP-0249: Direct MUC Invitations]
-- mux: `mux.ServeMux` now implements `info.FeatureIter`
+- mux: `mux.ServeMux` now implements `info.FeatureIter` and `items.Iter`
 - roster: the roster `Iter` now returns the roster version being iterated over
   from the `Version` method
 - roster: if a `stanza.Error` is returned from the `Push` handler it is now sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking
 
-- disco: the `Feature` type moved to `info.Feature`
+- disco: the `Feature` and `Item` types have been moved to the `info` and
+  `items` packages
 - roster: rename `version` attribute to `ver`
 - roster: the `Push` callback now takes the roster version
 - roster: `FetchIQ` now takes a `roster.IQ` instead of a `stanza.IQ` so that the

--- a/disco/handler_test.go
+++ b/disco/handler_test.go
@@ -6,15 +6,18 @@ package disco_test
 
 import (
 	"context"
+	"encoding/xml"
 	"testing"
 
+	"mellium.im/xmlstream"
 	"mellium.im/xmpp/disco"
+	"mellium.im/xmpp/disco/items"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/mux"
 	"mellium.im/xmpp/stanza"
 )
 
-func TestRoundTrip(t *testing.T) {
+func TestFeaturesRoundTrip(t *testing.T) {
 	m := mux.New(disco.Handle())
 	cs := xmpptest.NewClientServer(
 		xmpptest.ServerHandler(m),
@@ -34,5 +37,59 @@ func TestRoundTrip(t *testing.T) {
 	}
 	if len(info.Features) != 0 {
 		t.Errorf("got unexpected features %v", info.Features)
+	}
+}
+
+type itemHandler struct{}
+
+func (itemHandler) HandleXMPP(xmlstream.TokenReadEncoder, *xml.StartElement) error {
+	panic("should not be called")
+}
+
+func (itemHandler) ForItems(node string, f func(items.Item) error) error {
+	if node != "" {
+		return nil
+	}
+
+	return f(items.Item{
+		Name: disco.NSItems,
+	})
+}
+
+func TestItemsRoundTrip(t *testing.T) {
+	m := mux.New(
+		disco.Handle(),
+		mux.Handle(xml.Name{}, itemHandler{}),
+	)
+	cs := xmpptest.NewClientServer(
+		xmpptest.ServerHandler(m),
+	)
+
+	iter := disco.FetchItemsIQ(context.Background(), "", stanza.IQ{ID: "123"}, cs.Client)
+	allItems := []items.Item{}
+	for iter.Next() {
+		allItems = append(allItems, iter.Item())
+	}
+	if err := iter.Err(); err != nil {
+		t.Fatalf("error iterating over items: %v", err)
+	}
+	if len(allItems) != 1 || allItems[0].Name != disco.NSItems {
+		t.Errorf("wrong items: want=%s, got=%v", disco.NSItems, allItems)
+	}
+	err := iter.Close()
+	if err != nil {
+		t.Fatalf("error closing iterator: %v", err)
+	}
+
+	iter = disco.FetchItemsIQ(context.Background(), "node", stanza.IQ{ID: "123"}, cs.Client)
+	for iter.Next() {
+		t.Fatalf("error, got item %v but did not expect any", iter.Item())
+	}
+	if err := iter.Err(); err != nil {
+		t.Fatalf("error iterating over empty items: %v", err)
+	}
+	err = iter.Close()
+	if err != nil {
+		t.Fatalf("error closing empty iter: %v", err)
 	}
 }

--- a/disco/items/items.go
+++ b/disco/items/items.go
@@ -54,3 +54,9 @@ func (i Item) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	_, err := i.WriteXML(e)
 	return err
 }
+
+// Iter is the interface implemented by types that respond to service discovery
+// requests for items.
+type Iter interface {
+	ForItems(node string, f func(Item) error) error
+}

--- a/disco/items/items.go
+++ b/disco/items/items.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+// Package items contains service discovery items.
+//
+// These were separated out into a separate package to prevent import loops.
+package items // import "mellium.im/xmpp/disco/items"
+
+import (
+	"encoding/xml"
+
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp/jid"
+)
+
+const (
+	ns = `http://jabber.org/protocol/disco#items`
+)
+
+// Item represents a discovered item.
+type Item struct {
+	XMLName xml.Name `xml:"http://jabber.org/protocol/disco#items item"`
+	JID     jid.JID  `xml:"jid,attr"`
+	Name    string   `xml:"name,attr,omitempty"`
+	Node    string   `xml:"node,attr,omitempty"`
+}
+
+// TokenReader implements xmlstream.Marshaler.
+func (i Item) TokenReader() xml.TokenReader {
+	start := xml.StartElement{
+		Name: xml.Name{Space: ns, Local: "item"},
+		Attr: []xml.Attr{{
+			Name:  xml.Name{Local: "jid"},
+			Value: i.JID.String(),
+		}},
+	}
+	if i.Node != "" {
+		start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "node"}, Value: i.Node})
+	}
+	if i.Name != "" {
+		start.Attr = append(start.Attr, xml.Attr{Name: xml.Name{Local: "name"}, Value: i.Name})
+	}
+	return xmlstream.Wrap(nil, start)
+}
+
+// WriteXML implements xmlstream.WriterTo.
+func (i Item) WriteXML(w xmlstream.TokenWriter) (int, error) {
+	return xmlstream.Copy(w, i.TokenReader())
+}
+
+// MarshalXML implements xml.Marshaler.
+func (i Item) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
+	_, err := i.WriteXML(e)
+	return err
+}

--- a/disco/items/items_test.go
+++ b/disco/items/items_test.go
@@ -1,0 +1,41 @@
+// Copyright 2021 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package items_test
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp/disco"
+	"mellium.im/xmpp/disco/items"
+	"mellium.im/xmpp/internal/xmpptest"
+	"mellium.im/xmpp/jid"
+)
+
+var (
+	_ xml.Marshaler       = items.Item{}
+	_ xmlstream.Marshaler = items.Item{}
+	_ xmlstream.WriterTo  = items.Item{}
+)
+
+func TestEncode(t *testing.T) {
+	xmpptest.RunEncodingTests(t, []xmpptest.EncodingTestCase{
+		0: {
+			Value:       &items.Item{},
+			XML:         `<item xmlns="http://jabber.org/protocol/disco#items" jid=""></item>`,
+			NoUnmarshal: true,
+		},
+		1: {
+			Value: &items.Item{
+				XMLName: xml.Name{Space: disco.NSItems, Local: "item"},
+				JID:     jid.MustParse("example.net"),
+				Node:    "urn:example",
+				Name:    "test",
+			},
+			XML: `<item xmlns="http://jabber.org/protocol/disco#items" jid="example.net" node="urn:example" name="test"></item>`,
+		},
+	})
+}

--- a/disco/items_test.go
+++ b/disco/items_test.go
@@ -14,6 +14,7 @@ import (
 
 	"mellium.im/xmlstream"
 	"mellium.im/xmpp/disco"
+	"mellium.im/xmpp/disco/items"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/stanza"
@@ -21,12 +22,12 @@ import (
 
 var testFetchItems = [...]struct {
 	node  string
-	items map[string][]disco.Item
+	items map[string][]items.Item
 	err   error
 }{
 	0: {},
 	1: {
-		items: map[string][]disco.Item{
+		items: map[string][]items.Item{
 			"": {{
 				XMLName: xml.Name{Space: disco.NSItems, Local: "item"},
 				JID:     jid.MustParse("juliet@example.com"),
@@ -39,7 +40,7 @@ var testFetchItems = [...]struct {
 	},
 	2: {
 		node: "test",
-		items: map[string][]disco.Item{
+		items: map[string][]items.Item{
 			"test": {{
 				XMLName: xml.Name{Space: disco.NSItems, Local: "item"},
 				JID:     jid.MustParse("benvolio@example.org"),
@@ -50,7 +51,7 @@ var testFetchItems = [...]struct {
 
 type queryItems struct {
 	XMLName xml.Name     `xml:"http://jabber.org/protocol/disco#items query"`
-	Items   []disco.Item `xml:"item"`
+	Items   []items.Item `xml:"item"`
 }
 
 func TestFetchItems(t *testing.T) {
@@ -80,7 +81,7 @@ func TestFetchItems(t *testing.T) {
 				}),
 			)
 			iter := disco.FetchItemsIQ(context.Background(), tc.node, IQ, cs.Client)
-			items := make([]disco.Item, 0, len(tc.items))
+			items := make([]items.Item, 0, len(tc.items))
 			for iter.Next() {
 				items = append(items, iter.Item())
 			}

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -18,6 +18,7 @@ import (
 	"mellium.im/xmlstream"
 	"mellium.im/xmpp"
 	"mellium.im/xmpp/disco/info"
+	"mellium.im/xmpp/disco/items"
 	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/stanza"
 )
@@ -208,6 +209,43 @@ func (m *ServeMux) PresenceHandler(typ stanza.PresenceType, payload xml.Name) (h
 func (m *ServeMux) HandleXMPP(t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
 	h, _ := m.Handler(start.Name)
 	return h.HandleXMPP(t, start)
+}
+
+// ForItems implements items.Iter for the mux by iterating over all child items.
+func (m *ServeMux) ForItems(node string, f func(items.Item) error) error {
+	for _, h := range m.patterns {
+		if itemIter, ok := h.(items.Iter); ok {
+			err := itemIter.ForItems(node, f)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for _, h := range m.iqPatterns {
+		if itemIter, ok := h.(items.Iter); ok {
+			err := itemIter.ForItems(node, f)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for _, h := range m.msgPatterns {
+		if itemIter, ok := h.(items.Iter); ok {
+			err := itemIter.ForItems(node, f)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for _, h := range m.presencePatterns {
+		if itemIter, ok := h.(items.Iter); ok {
+			err := itemIter.ForItems(node, f)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // ForFeatures implements info.FeatureIter for the mux by iterating over all


### PR DESCRIPTION
This patch set allows handlers to implement an interface and respond to `disco#items` requests. All handlers are trusted to return items for all nodes.