### PR TITLE
form: provide access to fixed fields with no var

### DIFF
--- a/form/fields.go
+++ b/form/fields.go
@@ -69,6 +69,14 @@ type FieldData struct {
 	Label    string
 	Desc     string
 	Required bool
+
+	// Raw is the value of the field as it came over the wire with no type
+	// information.
+	// Generally speaking, Get methods on form should be used along with the field
+	// data's Var value to fetch fields and Raw should be ignored.
+	// Raw is mostly provided to access fixed type fields that do not have a
+	// variable name (and therefore cannot be referenced or set).
+	Raw []string
 }
 
 type field struct {

--- a/form/form.go
+++ b/form/form.go
@@ -71,7 +71,7 @@ func (d *Data) Instructions() string {
 
 // ForFields iterates over the fields of the form and calls a function for each
 // one, passing it information about the field.
-func (d *Data) ForFields(f func(FieldData)) {
+func (d *Data) ForFields(f func(data FieldData)) {
 	for _, field := range d.fields {
 		f(FieldData{
 			Type:     field.typ,
@@ -79,6 +79,7 @@ func (d *Data) ForFields(f func(FieldData)) {
 			Label:    field.label,
 			Desc:     field.desc,
 			Required: field.required,
+			Raw:      field.value,
 		})
 	}
 }


### PR DESCRIPTION
The data forms spec says that fixed fields do not have to have a
variable name since they can't be set anyways.
However, we currently rely on the variable name to get the value of
fields when iterating over all fields in a form.
This patch adds the raw, wire-format, untyped value of each field to its
data when iterating so that it can be used for fixed fields that cannot
be referenced otherwise, and for debugging.

Signed-off-by: Sam Whited <sam@samwhited.com>