### PR TITLE
examples/echobot: read the start token in xml.NewTokenDecoder

### DIFF
--- a/examples/echobot/echo.go
+++ b/examples/echobot/echo.go
@@ -83,7 +83,8 @@ func echo(ctx context.Context, addr, pass string, xmlIn, xmlOut io.Writer, logge
 	}
 
 	return s.Serve(xmpp.HandlerFunc(func(t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
-		d := xml.NewTokenDecoder(t)
+		d := xml.NewTokenDecoder(xmlstream.MultiReader(xmlstream.Token(*start), t))
+		d.Token()
 
 		// Ignore anything that's not a message. In a real system we'd want to at
 		// least respond to IQs.


### PR DESCRIPTION
Prevents XML syntax error on line 1: unexpected end element </message>

As suggested by @SamWhited in the chatroom