### PR TITLE
dial: simplify dialing and update docs

### DIFF
--- a/docs/dial.gv
+++ b/docs/dial.gv
@@ -1,13 +1,13 @@
 digraph {
 		label="Discovery and Connection"
 
-		dial[shape="oval", label="DialClient()"];
+		dial[shape="oval", label="dial.Client()"];
 
 		xmppssrv[shape="box", style=rounded, label="_xmpps SRV Lookup"];
 		xmppsifdot[shape="diamond", label="response = '.'?"];
 		xmppsdroprecord[shape="box", style=rounded, label="Drop '.' record"];
 		xmppsifempty[shape="diamond", label="len(response) = 0?"];
-		xmppsappenddomain[shape="box", style=rounded, label="Use domainpart:port"];
+		xmppsappenddomain[shape="box", style=rounded, label="Use domainpart:5223"];
 
 		xmppsrv[shape="box", style=rounded, label="_xmpp SRV Lookup"];
 		xmppifdot[shape="diamond", label="response = '.'?"];


### PR DESCRIPTION
This patch updates the docs to better show the state of dialing as it
currently stands, and simplifies the dialing algorithm by factoring out
legacy A/AAAA fallback and reworking how the TLS config is handled.

Signed-off-by: Sam Whited <sam@samwhited.com>