### PR TITLE
xmpp: add In and Out methods to session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
   disco#info requests
 - disco/info: new package containing the former `disco.Feature` and
   `disco.Identity` types
+- xmpp: add `In()` and `Out()` methods to `Session` for fetching stream info
 
 
 ### Fixed
@@ -69,6 +70,11 @@ All notable changes to this project will be documented in this file.
 - xmpp: empty IQ iters no longer return EOF when there is no payload
 - xmpp: `UnmarshalIQ` and `UnmarshalIQElement` no longer return an XML error
   on responses with no payload
+
+
+### Deprecated
+
+- xmpp: the `InSID` and `OutSID` methods on `Session`
 
 
 [XEP-0045: Multi-User Chat]: https://xmpp.org/extensions/xep-0045.html

--- a/session.go
+++ b/session.go
@@ -817,13 +817,29 @@ func (s *Session) State() SessionState {
 }
 
 // InSID returns the stream ID for the input stream.
+//
+// Deprecated: InSID exists for historical compatibility and will be removed in
+// a future version off this library. Use In instead.
 func (s *Session) InSID() string {
 	return s.in.ID
 }
 
 // OutSID returns the stream ID for the output stream.
+//
+// Deprecated: OutSID exists for historical compatibility and will be removed in
+// a future version off this library. Use Out instead.
 func (s *Session) OutSID() string {
 	return s.out.ID
+}
+
+// In returns information about the input stream.
+func (s *Session) In() stream.Info {
+	return s.in.Info
+}
+
+// Out returns information about the output stream.
+func (s *Session) Out() stream.Info {
+	return s.out.Info
 }
 
 // LocalAddr returns the Origin address for initiated connections, or the


### PR DESCRIPTION
This patch deprecates the InSID and OutSID methods in favor of returning
the entire stream info.
In the future this will let us more easily access the stream language,
SID, namespace used, etc. and unlocks major changes throughout the rest
of the package including removing the S2S state bit among others.

Fixes #175

Signed-off-by: Sam Whited <sam@samwhited.com>