### PR TITLE
internal/stream: remove s2s bool from stream send

### DIFF
--- a/blocklist/blocking_test.go
+++ b/blocklist/blocking_test.go
@@ -190,7 +190,7 @@ func (errReadWriter) Read([]byte) (int, error) {
 }
 
 func TestErroredDoesNotPanic(t *testing.T) {
-	s := xmpptest.NewSession(0, errReadWriter{})
+	s := xmpptest.NewClientSession(0, errReadWriter{})
 	iter := blocklist.Fetch(context.Background(), s)
 	if iter.Next() {
 		t.Errorf("expected false from call to next")

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -26,14 +26,7 @@ import (
 // is much faster than encoding.
 // Afterwards, clear the StreamRestartRequired bit and set the output stream
 // information.
-func Send(rw io.ReadWriter, streamData *stream.Info, s2s, ws bool, version stream.Version, lang string, to, from, id string) error {
-	switch s2s {
-	case true:
-		streamData.XMLNS = ns.Server
-	case false:
-		streamData.XMLNS = ns.Client
-	}
-
+func Send(rw io.ReadWriter, streamData *stream.Info, ws bool, version stream.Version, lang, to, from, id string) error {
 	streamData.ID = id
 	b := bufio.NewWriter(rw)
 	var err error

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"mellium.im/xmpp/internal/decl"
+	"mellium.im/xmpp/internal/ns"
 	intstream "mellium.im/xmpp/internal/stream"
 	"mellium.im/xmpp/stream"
 )
@@ -36,7 +37,12 @@ func TestSendNewS2S(t *testing.T) {
 				ids = "abc"
 			}
 			out := stream.Info{}
-			err := intstream.Send(&b, &out, tc.s2s, false, stream.Version{Major: 1, Minor: 0}, "und", "example.net", "test@example.net", ids)
+			if tc.s2s {
+				out.XMLNS = ns.Server
+			} else {
+				out.XMLNS = ns.Client
+			}
+			err := intstream.Send(&b, &out, false, stream.Version{Major: 1, Minor: 0}, "und", "example.net", "test@example.net", ids)
 
 			str := b.String()
 			if !strings.HasPrefix(str, decl.XMLHeader) {
@@ -86,7 +92,7 @@ func TestSendNewS2SReturnsWriteErr(t *testing.T) {
 	}{
 		nopReader{},
 		errWriter{},
-	}, &out, true, false, stream.Version{Major: 1, Minor: 0}, "und", "example.net", "test@example.net", "abc")
+	}, &out, false, stream.Version{Major: 1, Minor: 0}, "und", "example.net", "test@example.net", "abc")
 	if err != io.ErrUnexpectedEOF {
 		t.Errorf("Expected errWriterErr (%s) but got `%s`", io.ErrUnexpectedEOF, err)
 	}

--- a/internal/xmpptest/features.go
+++ b/internal/xmpptest/features.go
@@ -66,7 +66,7 @@ func RunFeatureTests(t *testing.T, tcs []FeatureTestCase) {
 			}
 
 			buf.Reset()
-			s := NewSession(tc.State, struct {
+			s := NewClientSession(tc.State, struct {
 				io.Reader
 				io.Writer
 			}{

--- a/internal/xmpptest/session_test.go
+++ b/internal/xmpptest/session_test.go
@@ -19,7 +19,7 @@ import (
 func TestNewSession(t *testing.T) {
 	state := xmpp.Secure | xmpp.InputStreamClosed
 	buf := new(bytes.Buffer)
-	s := xmpptest.NewSession(state, buf)
+	s := xmpptest.NewClientSession(state, buf)
 
 	if mask := s.State(); mask != state|xmpp.Ready {
 		t.Errorf("Got invalid state value: want=%d, got=%d", state, mask)

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -544,7 +544,7 @@ func TestFallback(t *testing.T) {
 		Reader: strings.NewReader(`<iq xmlns="jabber:client" to="romeo@example.com" from="juliet@example.com" id="123"><test/></iq>`),
 		Writer: buf,
 	}
-	s := xmpptest.NewSession(0, rw)
+	s := xmpptest.NewClientSession(0, rw)
 
 	r := s.TokenReader()
 	defer r.Close()

--- a/negotiator.go
+++ b/negotiator.go
@@ -10,6 +10,7 @@ import (
 	"io"
 
 	"mellium.im/xmpp/internal/attr"
+	"mellium.im/xmpp/internal/ns"
 	intstream "mellium.im/xmpp/internal/stream"
 	"mellium.im/xmpp/internal/wskey"
 	"mellium.im/xmpp/jid"
@@ -158,7 +159,12 @@ func negotiator(f func(*Session, *StreamConfig) StreamConfig) Negotiator {
 				location = in.To
 				origin = in.From
 
-				err = intstream.Send(s.Conn(), out, s.State()&S2S == S2S, websocket, stream.DefaultVersion, cfg.Lang, origin.String(), location.String(), attr.RandomID())
+				if s.State()&S2S == S2S {
+					out.XMLNS = ns.Server
+				} else {
+					out.XMLNS = ns.Client
+				}
+				err = intstream.Send(s.Conn(), out, websocket, stream.DefaultVersion, cfg.Lang, origin.String(), location.String(), attr.RandomID())
 				if err != nil {
 					nState.doRestart = false
 					return mask, nil, nState, err
@@ -168,7 +174,12 @@ func negotiator(f func(*Session, *StreamConfig) StreamConfig) Negotiator {
 				// one in response.
 				origin := s.LocalAddr()
 				location := s.RemoteAddr()
-				err = intstream.Send(s.Conn(), out, s.State()&S2S == S2S, websocket, stream.DefaultVersion, cfg.Lang, location.String(), origin.String(), "")
+				if s.State()&S2S == S2S {
+					out.XMLNS = ns.Server
+				} else {
+					out.XMLNS = ns.Client
+				}
+				err = intstream.Send(s.Conn(), out, websocket, stream.DefaultVersion, cfg.Lang, location.String(), origin.String(), "")
 				if err != nil {
 					nState.doRestart = false
 					return mask, nil, nState, err

--- a/receipts/receipts_test.go
+++ b/receipts/receipts_test.go
@@ -147,7 +147,7 @@ func TestClosedDoesNotPanic(t *testing.T) {
 	h := &receipts.Handler{}
 
 	bw := &bytes.Buffer{}
-	s := xmpptest.NewSession(0, bw)
+	s := xmpptest.NewClientSession(0, bw)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	err := h.SendMessageElement(ctx, s, nil, stanza.Message{
@@ -188,7 +188,7 @@ func TestRoundTrip(t *testing.T) {
 	h := &receipts.Handler{}
 
 	var req bytes.Buffer
-	s := xmpptest.NewSession(0, &req)
+	s := xmpptest.NewClientSession(0, &req)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/roster/roster_test.go
+++ b/roster/roster_test.go
@@ -225,7 +225,7 @@ func (errReadWriter) Read([]byte) (int, error) {
 }
 
 func TestErroredDoesNotPanic(t *testing.T) {
-	s := xmpptest.NewSession(0, errReadWriter{})
+	s := xmpptest.NewClientSession(0, errReadWriter{})
 	iter := roster.Fetch(context.Background(), s)
 	if iter.Next() {
 		t.Errorf("expected false from call to next")

--- a/session_test.go
+++ b/session_test.go
@@ -33,7 +33,7 @@ func TestClosedInputStream(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			mask := xmpp.SessionState(i)
 			buf := new(bytes.Buffer)
-			s := xmpptest.NewSession(mask, buf)
+			s := xmpptest.NewClientSession(mask, buf)
 			r := s.TokenReader()
 			defer r.Close()
 
@@ -53,7 +53,7 @@ func TestClosedOutputStream(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			mask := xmpp.SessionState(i)
 			buf := new(bytes.Buffer)
-			s := xmpptest.NewSession(mask, buf)
+			s := xmpptest.NewClientSession(mask, buf)
 			w := s.TokenWriter()
 			defer w.Close()
 
@@ -368,7 +368,7 @@ func TestServe(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			out := &bytes.Buffer{}
 			in := strings.NewReader(tc.in)
-			s := xmpptest.NewSession(tc.state, struct {
+			s := xmpptest.NewClientSession(tc.state, struct {
 				io.Reader
 				io.Writer
 			}{

--- a/starttls_test.go
+++ b/starttls_test.go
@@ -123,7 +123,7 @@ func (nopRWC) Close() error {
 func TestNegotiateServer(t *testing.T) {
 	stls := xmpp.StartTLS(&tls.Config{})
 	var b bytes.Buffer
-	c := xmpptest.NewSession(xmpp.Received, nopRWC{&b, &b})
+	c := xmpptest.NewClientSession(xmpp.Received, nopRWC{&b, &b})
 	_, rw, err := stls.Negotiate(context.Background(), c, nil)
 	switch {
 	case err != nil:
@@ -162,7 +162,7 @@ func TestNegotiateClient(t *testing.T) {
 			stls := xmpp.StartTLS(&tls.Config{})
 			r := strings.NewReader(strings.Join(test.responses, "\n"))
 			var b bytes.Buffer
-			c := xmpptest.NewSession(0, nopRWC{r, &b})
+			c := xmpptest.NewClientSession(0, nopRWC{r, &b})
 			mask, rw, err := stls.Negotiate(context.Background(), c, nil)
 			switch {
 			case test.err && err == nil:


### PR DESCRIPTION
Previously we set the namespace depending on whether a server-to-server
value was set. However, the namespace is set in the stream and may be
other values (such as the Jabber Component namespace) as well, so just
leave this alone and let the negotiator handle it.

Signed-off-by: Sam Whited <sam@samwhited.com>