### PR TITLE
all: be more strict about stanza namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - roster: `FetchIQ` now takes a `roster.IQ` instead of a `stanza.IQ` so that the
   version can be set
 - styling: decoding tokens now uses an iterator pattern
+- stanza: added stanza namespace argument to `Is`, `AddID`, and `AddOriginID`
 - xmpp: the `WebSocket` option on `StreamConfig` has been removed in favor of
   `websocket.Negotiator`
 - xmpp: the `IterIQ` and `IterIQElement` methods on `Session` now return the

--- a/blocklist/blocking.go
+++ b/blocklist/blocking.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the BSD 2-clause
 // license that can be found in the LICENSE file.
 
-// Package blocking implements blocking and unblocking of contacts.
+// Package blocklist implements blocking and unblocking of contacts.
 package blocklist // import "mellium.im/xmpp/blocklist"
 
 import (

--- a/delay/delay.go
+++ b/delay/delay.go
@@ -102,9 +102,9 @@ func (d *Delay) UnmarshalXML(decoder *xml.Decoder, start xml.StartElement) error
 }
 
 // Stanza inserts a delay into any stanza read through the stream.
-func Stanza(d Delay) xmlstream.Transformer {
+func Stanza(d Delay, stanzaNS string) xmlstream.Transformer {
 	return xmlstream.InsertFunc(func(start xml.StartElement, level uint64, w xmlstream.TokenWriter) error {
-		if !stanza.Is(start.Name) || level != 1 {
+		if !stanza.Is(start.Name, stanzaNS) || level != 1 {
 			return nil
 		}
 

--- a/history/history.go
+++ b/history/history.go
@@ -55,6 +55,7 @@ func (h *Handler) remove(id string) {
 	}
 }
 
+// HandleMessage implements mux.MessageHandler.
 func (h *Handler) HandleMessage(msg stanza.Message, r xmlstream.TokenReadEncoder) error {
 	// TODO: iterate through and find result.
 	msgTok, err := r.Token()

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -322,7 +322,7 @@ func (m *ServeMux) ForIdentities(node string, f func(info.Identity) error) error
 	return nil
 }
 
-// ForIdentities implements form.Iter for the mux by iterating over all child
+// ForForms implements form.Iter for the mux by iterating over all child
 // handlers.
 func (m *ServeMux) ForForms(node string, f func(*form.Data) error) error {
 	for _, h := range m.patterns {

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -506,7 +506,10 @@ func TestMux(t *testing.T) {
 			m := mux.New(tc.m...)
 			d := xml.NewDecoder(strings.NewReader(tc.x))
 			tok, _ := d.Token()
-			start := tok.(xml.StartElement)
+			start, ok := tok.(xml.StartElement)
+			if !ok {
+				t.Fatalf("did not get start element, got token %v of type %[1]T", tok)
+			}
 
 			err := m.HandleXMPP(nopEncoder{TokenReader: d}, &start)
 			switch {

--- a/mux/option.go
+++ b/mux/option.go
@@ -92,7 +92,7 @@ func Handle(n xml.Name, h xmpp.Handler) Option {
 		if h == nil {
 			panic("mux: nil handler")
 		}
-		if stanza.Is(n) {
+		if stanza.Is(n, "") {
 			panic("mux: tried to register stanza handler with Handle, use HandleIQ, HandleMessage, or HandlePresence instead")
 		}
 		if _, ok := m.patterns[n]; ok {

--- a/session.go
+++ b/session.go
@@ -258,12 +258,8 @@ func negotiateSession(ctx context.Context, location, origin jid.JID, rw io.ReadW
 	}
 
 	s.in.d = intstream.Reader(s.in.d)
-	streamNS := ns.Client
-	if s.state&S2S == S2S {
-		streamNS = ns.Server
-	}
-	se := &stanzaEncoder{TokenWriteFlusher: s.out.e, ns: streamNS}
-	if s.state&S2S == S2S {
+	se := &stanzaEncoder{TokenWriteFlusher: s.out.e, ns: s.out.Info.XMLNS}
+	if s.out.Info.XMLNS == ns.Server {
 		se.from = s.LocalAddr()
 	}
 	s.out.e = se
@@ -517,7 +513,7 @@ func handleInputStream(s *Session, handler Handler) (err error) {
 	}
 
 	// If this is a stanza, normalize the "from" attribute.
-	if stanza.Is(start.Name) {
+	if stanza.Is(start.Name, s.in.XMLNS) {
 		for i, attr := range start.Attr {
 			if attr.Name.Local == "from" /*&& attr.Name.Space == start.Name.Space*/ {
 				local := s.LocalAddr().Bare().String()


### PR DESCRIPTION
Previously we were checking if something was a stanza based on faulty
assumptions (that there were only two valid stanza namespaces) and
without precision (we'd accept it if it were either namespace or none
instead of only accepting the actual namespace used by the stream).
This PR fixes this to ensure that eg. a vulnerability that causes the
server to allow {jabber:server}message's sent over a jabber:client
stream without any of the normal security measures still won't affect
this library (hopefully).

This PR updates all locations to use the new APIs, but does not
necessarily perform the correct checks. A followup PR will be rquired to
upgrade some of the packages (eg. mux) to use the correct namespace.

Signed-off-by: Sam Whited <sam@samwhited.com>