### PR TITLE
all: add strict namespace checking to mux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - disco: the `Feature`, `Identity`, and `Item` types have been moved to the
   `info` and `items` packages
+- mux: make namespace checking stricter by adding argument to `New`
 - roster: rename `version` attribute to `ver`
 - roster: the `Push` callback now takes the roster version
 - roster: `FetchIQ` now takes a `roster.IQ` instead of a `stanza.IQ` so that the

--- a/blocklist/blocking_test.go
+++ b/blocklist/blocking_test.go
@@ -15,6 +15,7 @@ import (
 
 	"mellium.im/xmlstream"
 	"mellium.im/xmpp/blocklist"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/mux"
@@ -111,7 +112,7 @@ func TestFetch(t *testing.T) {
 					}
 				},
 			}
-			m := mux.New(blocklist.Handle(h))
+			m := mux.New(ns.Client, blocklist.Handle(h))
 			cs := xmpptest.NewClientServer(xmpptest.ServerHandler(m))
 
 			err := blocklist.AddIQ(context.Background(), IQ, cs.Client, tc.items...)

--- a/carbons/handler_test.go
+++ b/carbons/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"mellium.im/xmpp/carbons"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/mux"
 	"mellium.im/xmpp/stanza"
@@ -34,7 +35,7 @@ func TestHandler(t *testing.T) {
 			return nil
 		},
 	}
-	m := mux.New(carbons.Handle(h))
+	m := mux.New(ns.Client, carbons.Handle(h))
 	s := xmpptest.NewClientServer(xmpptest.ClientHandler(m))
 	defer s.Close()
 	const recv = `<message xmlns='jabber:client'

--- a/disco/handler_test.go
+++ b/disco/handler_test.go
@@ -12,13 +12,14 @@ import (
 	"mellium.im/xmlstream"
 	"mellium.im/xmpp/disco"
 	"mellium.im/xmpp/disco/items"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/mux"
 	"mellium.im/xmpp/stanza"
 )
 
 func TestFeaturesRoundTrip(t *testing.T) {
-	m := mux.New(disco.Handle())
+	m := mux.New(ns.Client, disco.Handle())
 	cs := xmpptest.NewClientServer(
 		xmpptest.ServerHandler(m),
 	)
@@ -58,6 +59,7 @@ func (itemHandler) ForItems(node string, f func(items.Item) error) error {
 
 func TestItemsRoundTrip(t *testing.T) {
 	m := mux.New(
+		ns.Client,
 		disco.Handle(),
 		mux.Handle(xml.Name{}, itemHandler{}),
 	)

--- a/examples/im/main.go
+++ b/examples/im/main.go
@@ -207,7 +207,7 @@ func main() {
 	}
 
 	mucClient := &muc.Client{}
-	mux := mux.New(muc.HandleClient(mucClient))
+	mux := mux.New("jabber:client", muc.HandleClient(mucClient))
 	go func() {
 		err := session.Serve(mux)
 		if err != nil {

--- a/history/history_test.go
+++ b/history/history_test.go
@@ -27,6 +27,7 @@ func TestRoundTrip(t *testing.T) {
 		return nil
 	}))
 	m := mux.New(
+		"",
 		mux.IQFunc(stanza.SetIQ, xml.Name{Space: history.NS, Local: "query"}, func(iq stanza.IQ, e xmlstream.TokenReadEncoder, start *xml.StartElement) error {
 			xmlstream.Copy(e, stanza.Message{}.Wrap(xmlstream.Wrap(
 				nil,

--- a/muc/integration_test.go
+++ b/muc/integration_test.go
@@ -19,6 +19,7 @@ import (
 	"mellium.im/xmpp/disco/items"
 	"mellium.im/xmpp/internal/integration"
 	"mellium.im/xmpp/internal/integration/prosody"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/muc"
 	"mellium.im/xmpp/mux"
@@ -49,7 +50,7 @@ func integrationJoinRoom(ctx context.Context, t *testing.T, cmd *integration.Cmd
 	}
 	mucClient := &muc.Client{}
 	go func() {
-		m := mux.New(muc.HandleClient(mucClient))
+		m := mux.New(ns.Client, muc.HandleClient(mucClient))
 		err := session.Serve(m)
 		if err != nil {
 			t.Logf("error from serve: %v", err)
@@ -178,7 +179,7 @@ func integrationJoinErr(ctx context.Context, t *testing.T, cmd *integration.Cmd)
 	}
 	mucClient := &muc.Client{}
 	go func() {
-		m := mux.New(muc.HandleClient(mucClient))
+		m := mux.New(ns.Client, muc.HandleClient(mucClient))
 		err := session.Serve(m)
 		if err != nil {
 			t.Logf("error from serve: %v", err)

--- a/muc/muc_test.go
+++ b/muc/muc_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"mellium.im/xmlstream"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/muc"
@@ -22,7 +23,7 @@ import (
 func TestJoinPartMuc(t *testing.T) {
 	j := jid.MustParse("room@example.net/me")
 	h := &muc.Client{}
-	m := mux.New(muc.HandleClient(h))
+	m := mux.New(ns.Client, muc.HandleClient(h))
 	s := xmpptest.NewClientServer(
 		xmpptest.ClientHandler(m),
 		xmpptest.ServerHandlerFunc(func(t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
@@ -64,7 +65,7 @@ func TestJoinPartMuc(t *testing.T) {
 func TestJoinError(t *testing.T) {
 	j := jid.MustParse("room@example.net/me")
 	h := &muc.Client{}
-	m := mux.New(muc.HandleClient(h))
+	m := mux.New(ns.Client, muc.HandleClient(h))
 	s := xmpptest.NewClientServer(
 		xmpptest.ClientHandler(m),
 		xmpptest.ServerHandlerFunc(func(t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
@@ -100,7 +101,7 @@ func TestJoinError(t *testing.T) {
 func TestPartError(t *testing.T) {
 	j := jid.MustParse("room@example.net/me")
 	h := &muc.Client{}
-	m := mux.New(muc.HandleClient(h))
+	m := mux.New(ns.Client, muc.HandleClient(h))
 	errHotelCalifornia := stanza.Error{
 		Type:      stanza.Auth,
 		Condition: stanza.NotAllowed,

--- a/muc/room_integration_test.go
+++ b/muc/room_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"mellium.im/xmpp"
 	"mellium.im/xmpp/internal/integration"
 	"mellium.im/xmpp/internal/integration/prosody"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/muc"
 	"mellium.im/xmpp/mux"
@@ -86,7 +87,7 @@ func integrationMediatedInvite(ctx context.Context, t *testing.T, cmd *integrati
 
 	mucClient := &muc.Client{}
 	go func() {
-		m := mux.New(muc.HandleClient(mucClient))
+		m := mux.New(ns.Client, muc.HandleClient(mucClient))
 		err := userOneSession.Serve(m)
 		if err != nil {
 			t.Logf("error from %s serve: %v", userOne, err)
@@ -99,7 +100,7 @@ func integrationMediatedInvite(ctx context.Context, t *testing.T, cmd *integrati
 				errChan <- nil
 			},
 		}
-		m := mux.New(muc.HandleClient(inviteClient))
+		m := mux.New(ns.Client, muc.HandleClient(inviteClient))
 		err := userTwoSession.Serve(m)
 		if err != nil {
 			t.Logf("error from %s serve: %v", userTwo, err)
@@ -154,7 +155,7 @@ func integrationSetAffiliation(ctx context.Context, t *testing.T, cmd *integrati
 
 	mucClientOne := &muc.Client{}
 	go func() {
-		m := mux.New(muc.HandleClient(mucClientOne))
+		m := mux.New(ns.Client, muc.HandleClient(mucClientOne))
 		err := userOneSession.Serve(m)
 		if err != nil {
 			t.Logf("error from %s serve: %v", userOne, err)
@@ -168,7 +169,7 @@ func integrationSetAffiliation(ctx context.Context, t *testing.T, cmd *integrati
 		},
 	}
 	go func(itemChan chan<- muc.Item) {
-		m := mux.New(muc.HandleClient(mucClientTwo))
+		m := mux.New(ns.Client, muc.HandleClient(mucClientTwo))
 		err := userTwoSession.Serve(m)
 		if err != nil {
 			t.Logf("error from %s serve: %v", userTwo, err)

--- a/muc/room_test.go
+++ b/muc/room_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"mellium.im/xmlstream"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/muc"
@@ -23,8 +24,8 @@ func TestMediatedInvite(t *testing.T) {
 	j := jid.MustParse("room@example.net/me")
 	h := &muc.Client{}
 	inviteChan := make(chan muc.Invitation, 1)
-	m := mux.New(muc.HandleClient(h))
-	server := mux.New(
+	m := mux.New(ns.Client, muc.HandleClient(h))
+	server := mux.New(ns.Client,
 		mux.PresenceFunc("", xml.Name{Local: "x"}, func(p stanza.Presence, r xmlstream.TokenReadEncoder) error {
 			// Send back a self presence, indicating that the join is complete.
 			p.To, p.From = p.From, p.To
@@ -73,6 +74,7 @@ func TestDirectInvite(t *testing.T) {
 	inviteChan := make(chan muc.Invitation, 1)
 	s := xmpptest.NewClientServer(
 		xmpptest.ServerHandler(mux.New(
+			ns.Client,
 			muc.HandleInvite(func(invite muc.Invitation) {
 				inviteChan <- invite
 			}),
@@ -119,8 +121,9 @@ func TestSetAffiliation(t *testing.T) {
 	j := jid.MustParse("room@example.net/me")
 	h := &muc.Client{}
 	handled := make(chan string, 1)
-	m := mux.New(muc.HandleClient(h))
+	m := mux.New(ns.Client, muc.HandleClient(h))
 	server := mux.New(
+		ns.Client,
 		mux.PresenceFunc("", xml.Name{Local: "x"}, func(p stanza.Presence, r xmlstream.TokenReadEncoder) error {
 			// Send back a self presence, indicating that the join is complete.
 			p.To, p.From = p.From, p.To
@@ -176,8 +179,9 @@ func TestSetSubject(t *testing.T) {
 	j := jid.MustParse("room@example.net/me")
 	h := &muc.Client{}
 	handled := make(chan string, 1)
-	m := mux.New(muc.HandleClient(h))
+	m := mux.New(ns.Client, muc.HandleClient(h))
 	server := mux.New(
+		ns.Client,
 		mux.PresenceFunc("", xml.Name{Local: "x"}, func(p stanza.Presence, r xmlstream.TokenReadEncoder) error {
 			// Send back a self presence, indicating that the join is complete.
 			p.To, p.From = p.From, p.To

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -54,11 +54,12 @@ type ServeMux struct {
 	iqPatterns       map[pattern]IQHandler
 	msgPatterns      map[pattern]MessageHandler
 	presencePatterns map[pattern]PresenceHandler
+	stanzaNS         string
 }
 
 // New allocates and returns a new ServeMux.
-func New(opt ...Option) *ServeMux {
-	m := &ServeMux{}
+func New(stanzaNS string, opt ...Option) *ServeMux {
+	m := &ServeMux{stanzaNS: stanzaNS}
 	for _, o := range opt {
 		o(m)
 	}
@@ -89,13 +90,15 @@ func (m *ServeMux) Handler(name xml.Name) (h xmpp.Handler, ok bool) {
 		return h, true
 	}
 
-	switch name.Local {
-	case iqStanza:
-		return xmpp.HandlerFunc(m.iqRouter), true
-	case msgStanza:
-		return xmpp.HandlerFunc(m.msgRouter), true
-	case presStanza:
-		return xmpp.HandlerFunc(m.presenceRouter), true
+	if stanza.Is(name, m.stanzaNS) {
+		switch name.Local {
+		case iqStanza:
+			return xmpp.HandlerFunc(m.iqRouter), true
+		case msgStanza:
+			return xmpp.HandlerFunc(m.msgRouter), true
+		case presStanza:
+			return xmpp.HandlerFunc(m.presenceRouter), true
+		}
 	}
 
 	return nopHandler{}, false

--- a/ping/integration_test.go
+++ b/ping/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"mellium.im/xmpp/internal/integration/mcabber"
 	"mellium.im/xmpp/internal/integration/prosody"
 	"mellium.im/xmpp/internal/integration/sendxmpp"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/mux"
 	"mellium.im/xmpp/ping"
 	"mellium.im/xmpp/stanza"
@@ -57,7 +58,7 @@ func integrationRecvPing(ctx context.Context, t *testing.T, cmd *integration.Cmd
 		t.Fatalf("error connecting: %v", err)
 	}
 	go func() {
-		m := mux.New(mux.IQFunc(stanza.GetIQ, xml.Name{Local: "ping", Space: ping.NS},
+		m := mux.New(ns.Client, mux.IQFunc(stanza.GetIQ, xml.Name{Local: "ping", Space: ping.NS},
 			func(iq stanza.IQ, t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
 				err := ping.Handler{}.HandleIQ(iq, t, start)
 				gotPing <- struct{}{}

--- a/ping/ping_test.go
+++ b/ping/ping_test.go
@@ -12,6 +12,7 @@ import (
 
 	"mellium.im/xmlstream"
 	"mellium.im/xmpp/disco/info"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/mux"
@@ -56,7 +57,7 @@ type tokenReadEncoder struct {
 }
 
 func TestRoundTrip(t *testing.T) {
-	m := mux.New(ping.Handle())
+	m := mux.New(ns.Client, ping.Handle())
 	cs := xmpptest.NewClientServer(
 		xmpptest.ServerHandler(m),
 	)
@@ -74,7 +75,7 @@ func TestWrongIQType(t *testing.T) {
 	tok, _ := d.Token()
 	start := tok.(xml.StartElement)
 
-	m := mux.New(mux.IQ(stanza.SetIQ, xml.Name{Local: "ping", Space: ping.NS}, ping.Handler{}))
+	m := mux.New(ns.Client, mux.IQ(stanza.SetIQ, xml.Name{Local: "ping", Space: ping.NS}, ping.Handler{}))
 	err := m.HandleXMPP(tokenReadEncoder{
 		TokenReader: d,
 		Encoder:     e,
@@ -100,7 +101,7 @@ func TestBadPayloadLocalname(t *testing.T) {
 	tok, _ := d.Token()
 	start := tok.(xml.StartElement)
 
-	m := mux.New(mux.IQ(stanza.GetIQ, xml.Name{Local: "badlocal", Space: ping.NS}, ping.Handler{}))
+	m := mux.New(ns.Client, mux.IQ(stanza.GetIQ, xml.Name{Local: "badlocal", Space: ping.NS}, ping.Handler{}))
 	err := m.HandleXMPP(tokenReadEncoder{
 		TokenReader: d,
 		Encoder:     e,
@@ -126,7 +127,7 @@ func TestBadPayloadNamespace(t *testing.T) {
 	tok, _ := d.Token()
 	start := tok.(xml.StartElement)
 
-	m := mux.New(mux.IQ(stanza.GetIQ, xml.Name{Local: "ping", Space: "badnamespace"}, ping.Handler{}))
+	m := mux.New(ns.Client, mux.IQ(stanza.GetIQ, xml.Name{Local: "ping", Space: "badnamespace"}, ping.Handler{}))
 	err := m.HandleXMPP(tokenReadEncoder{
 		TokenReader: d,
 		Encoder:     e,

--- a/receipts/receipts_test.go
+++ b/receipts/receipts_test.go
@@ -206,7 +206,7 @@ func TestRoundTrip(t *testing.T) {
 	var b strings.Builder
 	e := xml.NewEncoder(&b)
 
-	m := mux.New(receipts.Handle(h))
+	m := mux.New(ns.Client, receipts.Handle(h))
 	err = m.HandleXMPP(struct {
 		xml.TokenReader
 		xmlstream.Encoder

--- a/roster/roster_test.go
+++ b/roster/roster_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"mellium.im/xmlstream"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/mux"
@@ -144,7 +145,7 @@ func TestReceivePush(t *testing.T) {
 		t.Errorf("unexpected error popping start token: %v", err)
 	}
 	start := tok.(xml.StartElement)
-	m := mux.New(roster.Handle(h))
+	m := mux.New(ns.Client, roster.Handle(h))
 	err = m.HandleXMPP(struct {
 		xml.TokenReader
 		xmlstream.Encoder
@@ -190,7 +191,7 @@ func TestReceivePushError(t *testing.T) {
 		t.Errorf("unexpected error popping start token: %v", err)
 	}
 	start := tok.(xml.StartElement)
-	m := mux.New(roster.Handle(h))
+	m := mux.New(ns.Client, roster.Handle(h))
 	err = m.HandleXMPP(struct {
 		xml.TokenReader
 		xmlstream.Encoder

--- a/xtime/time_test.go
+++ b/xtime/time_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"mellium.im/xmlstream"
+	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/mux"
 	"mellium.im/xmpp/xtime"
@@ -33,7 +34,7 @@ func TestRoundTrip(t *testing.T) {
 			return serverTime
 		},
 	}
-	m := mux.New(xtime.Handle(h))
+	m := mux.New(ns.Client, xtime.Handle(h))
 	cs := xmpptest.NewClientServer(
 		xmpptest.ServerHandler(m),
 	)


### PR DESCRIPTION
Previously anything that had a local name that looked like a stanza
("message", "iq", or "presence") would be treated as such, opening us up
to potential vulnerabilities in servers that allow a
{jabber:server}message on a jabber:client stream but don't treat it as a
stanza, for example.
Being more strict about checking namespaces helps to avoid this issue,
but does require a breaking change to the mux API.

Signed-off-by: Sam Whited <sam@samwhited.com>