### PR TITLE
all: bump deps and target Go version

### DIFF
--- a/examples/commands/go.mod
+++ b/examples/commands/go.mod
@@ -10,7 +10,7 @@ require (
 	golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744 // indirect
 	golang.org/x/tools v0.1.1 // indirect
 	mellium.im/sasl v0.2.1
-	mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c
+	mellium.im/xmlstream v0.15.3
 	mellium.im/xmpp v0.19.0
 )
 

--- a/examples/commands/go.sum
+++ b/examples/commands/go.sum
@@ -64,5 +64,5 @@ mellium.im/reader v0.1.0 h1:UUEMev16gdvaxxZC7fC08j7IzuDKh310nB6BlwnxTww=
 mellium.im/reader v0.1.0/go.mod h1:F+X5HXpkIfJ9EE1zHQG9lM/hO946iYAmU7xjg5dsQHI=
 mellium.im/sasl v0.2.1 h1:nspKSRg7/SyO0cRGY71OkfHab8tf9kCts6a6oTDut0w=
 mellium.im/sasl v0.2.1/go.mod h1:ROaEDLQNuf9vjKqE1SrAfnsobm2YKXT1gnN1uDp1PjQ=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c h1:1RCzOXu94kvNjuCC89G+5XTP6GOdoDrLsYdGIryyc2Y=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=
+mellium.im/xmlstream v0.15.3 h1:VoxDwNWEa99nFEL5JbdVYFIWZTvp1mllAUrydrZE2po=
+mellium.im/xmlstream v0.15.3/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=

--- a/examples/echobot/go.mod
+++ b/examples/echobot/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/text v0.3.4 // indirect
 	mellium.im/sasl v0.2.1
-	mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c
+	mellium.im/xmlstream v0.15.3
 	mellium.im/xmpp v0.16.0
 )
 

--- a/examples/echobot/go.sum
+++ b/examples/echobot/go.sum
@@ -25,5 +25,5 @@ mellium.im/reader v0.1.0 h1:UUEMev16gdvaxxZC7fC08j7IzuDKh310nB6BlwnxTww=
 mellium.im/reader v0.1.0/go.mod h1:F+X5HXpkIfJ9EE1zHQG9lM/hO946iYAmU7xjg5dsQHI=
 mellium.im/sasl v0.2.1 h1:nspKSRg7/SyO0cRGY71OkfHab8tf9kCts6a6oTDut0w=
 mellium.im/sasl v0.2.1/go.mod h1:ROaEDLQNuf9vjKqE1SrAfnsobm2YKXT1gnN1uDp1PjQ=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c h1:1RCzOXu94kvNjuCC89G+5XTP6GOdoDrLsYdGIryyc2Y=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=
+mellium.im/xmlstream v0.15.3 h1:VoxDwNWEa99nFEL5JbdVYFIWZTvp1mllAUrydrZE2po=
+mellium.im/xmlstream v0.15.3/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=

--- a/examples/im/go.sum
+++ b/examples/im/go.sum
@@ -25,5 +25,5 @@ mellium.im/reader v0.1.0 h1:UUEMev16gdvaxxZC7fC08j7IzuDKh310nB6BlwnxTww=
 mellium.im/reader v0.1.0/go.mod h1:F+X5HXpkIfJ9EE1zHQG9lM/hO946iYAmU7xjg5dsQHI=
 mellium.im/sasl v0.2.1 h1:nspKSRg7/SyO0cRGY71OkfHab8tf9kCts6a6oTDut0w=
 mellium.im/sasl v0.2.1/go.mod h1:ROaEDLQNuf9vjKqE1SrAfnsobm2YKXT1gnN1uDp1PjQ=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c h1:1RCzOXu94kvNjuCC89G+5XTP6GOdoDrLsYdGIryyc2Y=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=
+mellium.im/xmlstream v0.15.3 h1:VoxDwNWEa99nFEL5JbdVYFIWZTvp1mllAUrydrZE2po=
+mellium.im/xmlstream v0.15.3/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=

--- a/examples/msgrepl/go.mod
+++ b/examples/msgrepl/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/text v0.3.4 // indirect
 	mellium.im/sasl v0.2.1
-	mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c
+	mellium.im/xmlstream v0.15.3
 	mellium.im/xmpp v0.16.0
 )
 

--- a/examples/msgrepl/go.sum
+++ b/examples/msgrepl/go.sum
@@ -25,5 +25,5 @@ mellium.im/reader v0.1.0 h1:UUEMev16gdvaxxZC7fC08j7IzuDKh310nB6BlwnxTww=
 mellium.im/reader v0.1.0/go.mod h1:F+X5HXpkIfJ9EE1zHQG9lM/hO946iYAmU7xjg5dsQHI=
 mellium.im/sasl v0.2.1 h1:nspKSRg7/SyO0cRGY71OkfHab8tf9kCts6a6oTDut0w=
 mellium.im/sasl v0.2.1/go.mod h1:ROaEDLQNuf9vjKqE1SrAfnsobm2YKXT1gnN1uDp1PjQ=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c h1:1RCzOXu94kvNjuCC89G+5XTP6GOdoDrLsYdGIryyc2Y=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=
+mellium.im/xmlstream v0.15.3 h1:VoxDwNWEa99nFEL5JbdVYFIWZTvp1mllAUrydrZE2po=
+mellium.im/xmlstream v0.15.3/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module mellium.im/xmpp
 
-go 1.15
+go 1.16
 
 require (
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
@@ -10,5 +10,5 @@ require (
 	golang.org/x/text v0.3.2
 	golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e
 	mellium.im/sasl v0.2.1
-	mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c
+	mellium.im/xmlstream v0.15.3
 )

--- a/go.sum
+++ b/go.sum
@@ -20,5 +20,5 @@ mellium.im/reader v0.1.0 h1:UUEMev16gdvaxxZC7fC08j7IzuDKh310nB6BlwnxTww=
 mellium.im/reader v0.1.0/go.mod h1:F+X5HXpkIfJ9EE1zHQG9lM/hO946iYAmU7xjg5dsQHI=
 mellium.im/sasl v0.2.1 h1:nspKSRg7/SyO0cRGY71OkfHab8tf9kCts6a6oTDut0w=
 mellium.im/sasl v0.2.1/go.mod h1:ROaEDLQNuf9vjKqE1SrAfnsobm2YKXT1gnN1uDp1PjQ=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c h1:1RCzOXu94kvNjuCC89G+5XTP6GOdoDrLsYdGIryyc2Y=
-mellium.im/xmlstream v0.15.3-0.20210221202126-7cc1407dad4c/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=
+mellium.im/xmlstream v0.15.3 h1:VoxDwNWEa99nFEL5JbdVYFIWZTvp1mllAUrydrZE2po=
+mellium.im/xmlstream v0.15.3/go.mod h1:7SUlP7f2qnMczK+Cu/OFgqaIhldMolVjo8np7xG41D0=


### PR DESCRIPTION
Prepare for a release by bumping the dependency on mellium.im/xmlstream
to v0.15.3 and update the targeted Go version to 1.16 (the earliest
supported release).

Signed-off-by: Sam Whited <sam@samwhited.com>