### PR TITLE
xmpp: remove InSID and OutSID methods

### DIFF
--- a/session.go
+++ b/session.go
@@ -812,22 +812,6 @@ func (s *Session) State() SessionState {
 	return s.state
 }
 
-// InSID returns the stream ID for the input stream.
-//
-// Deprecated: InSID exists for historical compatibility and will be removed in
-// a future version off this library. Use In instead.
-func (s *Session) InSID() string {
-	return s.in.ID
-}
-
-// OutSID returns the stream ID for the output stream.
-//
-// Deprecated: OutSID exists for historical compatibility and will be removed in
-// a future version off this library. Use Out instead.
-func (s *Session) OutSID() string {
-	return s.out.ID
-}
-
 // In returns information about the input stream.
 func (s *Session) In() stream.Info {
 	return s.in.Info


### PR DESCRIPTION
The InSID and OutSID methods on Session are deprecated since v0.20.0 and can now be removed. Fixes #178

Signed-off-by: Julian Huhn <julian@huhn.dev>