### PR TITLE
xtime: re-enable ejabberd integration tests

### DIFF
--- a/xtime/integration_test.go
+++ b/xtime/integration_test.go
@@ -16,6 +16,7 @@ import (
 	"mellium.im/sasl"
 	"mellium.im/xmpp"
 	"mellium.im/xmpp/internal/integration"
+	"mellium.im/xmpp/internal/integration/ejabberd"
 	"mellium.im/xmpp/internal/integration/prosody"
 	"mellium.im/xmpp/xtime"
 )
@@ -27,13 +28,11 @@ func TestIntegrationRequestTime(t *testing.T) {
 	)
 	prosodyRun(integrationRequestTime)
 
-	// See: https://github.com/processone/ejabberd/issues/3454
-	//
-	// ejabberdRun := ejabberd.Test(context.TODO(), t,
-	// 	integration.Log(),
-	// 	ejabberd.ListenC2S(),
-	// )
-	// ejabberdRun(integrationRequestTime)
+	ejabberdRun := ejabberd.Test(context.TODO(), t,
+		integration.Log(),
+		ejabberd.ListenC2S(),
+	)
+	ejabberdRun(integrationRequestTime)
 }
 
 func integrationRequestTime(ctx context.Context, t *testing.T, cmd *integration.Cmd) {


### PR DESCRIPTION
Since processone/ejabberd#3454 has been fixed and trickled down into our
CI machine we can re-enable the test that discovered the bug.

Signed-off-by: Sam Whited <sam@samwhited.com>