### PR TITLE
stream, .builds: linter fixes

### DIFF
--- a/.builds/validate.yml
+++ b/.builds/validate.yml
@@ -43,7 +43,8 @@ tasks:
       go vet ./...
       gofmt -s -l . && [ -z "$(gofmt -s -l .)" ]
 
-      staticcheck ./...
+      # See: https://staticcheck.io/docs/checks
+      staticcheck -checks inherit,ST1000,ST1003,ST1016,ST1020,ST1021,ST1022,ST1023 ./...
       # gosec does not handle modules correctly.
       # See: https://github.com/securego/gosec/issues/622
       # It also does not handle deferred close statements correctly (G307).

--- a/stream/version.go
+++ b/stream/version.go
@@ -66,7 +66,7 @@ func (v Version) Less(b Version) bool {
 	return v.Major < b.Major || (v.Major == b.Major && v.Minor < b.Minor)
 }
 
-// Prints a string representation of the XMPP version in the form "Major.Minor".
+// String returns the XMPP version in the form "Major.Minor".
 func (v Version) String() string {
 	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
 }


### PR DESCRIPTION
Add some missing lints that staticcheck does not run by default and fix a doc comment that was incorrect and would have triggered one of the new checks.