### PR TITLE
styling: remove style from tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - xmpp: the deprecated methods `InSID` and `OutSID` have been dropped in favor
   of `In` and `Out`
+- styling: individual tokens no longer contains their own Style, use Decoder's
+  `Style()` method instead
 
 
 ### Added:

--- a/styling/example_test.go
+++ b/styling/example_test.go
@@ -24,20 +24,20 @@ but *most* people shorten it.`)
 	for d.Next() {
 		tok := d.Token()
 
-		switch {
-		case tok.Mask&styling.SpanEmphStart == styling.SpanEmphStart:
+		switch style := d.Style(); {
+		case style&styling.SpanEmphStart == styling.SpanEmphStart:
 			out.WriteString("<em><code>")
 			out.Write(tok.Data)
 			out.WriteString("</code>")
-		case tok.Mask&styling.SpanStrongStart == styling.SpanStrongStart:
+		case style&styling.SpanStrongStart == styling.SpanStrongStart:
 			out.WriteString("<strong><code>")
 			out.Write(tok.Data)
 			out.WriteString("</code>")
-		case tok.Mask&styling.SpanEmphEnd == styling.SpanEmphEnd:
+		case style&styling.SpanEmphEnd == styling.SpanEmphEnd:
 			out.WriteString("<code>")
 			out.Write(tok.Data)
 			out.WriteString("</code></em>")
-		case tok.Mask&styling.SpanStrongEnd == styling.SpanStrongEnd:
+		case style&styling.SpanStrongEnd == styling.SpanStrongEnd:
 			out.WriteString("<code>")
 			out.Write(tok.Data)
 			out.WriteString("</code></strong>")

--- a/styling/styling_test.go
+++ b/styling/styling_test.go
@@ -37,6 +37,7 @@ func TestCopyToken(t *testing.T) {
 
 type tokenAndStyle struct {
 	styling.Token
+	Mask  styling.Style
 	Quote uint
 }
 
@@ -54,8 +55,8 @@ var decoderTestCases = []struct {
 				Token: styling.Token{
 					Data: []byte("````"),
 					Info: []byte("`"),
-					Mask: styling.BlockPre | styling.BlockPreStart,
 				},
+				Mask: styling.BlockPre | styling.BlockPreStart,
 			},
 		},
 	},
@@ -83,20 +84,20 @@ and two`,
 			{
 				Token: styling.Token{
 					Data: []byte("```\n"),
-					Mask: styling.BlockPre | styling.BlockPreStart,
 				},
+				Mask: styling.BlockPre | styling.BlockPreStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("pre *fmt* ```\n"),
-					Mask: styling.BlockPre,
 				},
+				Mask: styling.BlockPre,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("```\n"),
-					Mask: styling.BlockPre | styling.BlockPreEnd,
 				},
+				Mask: styling.BlockPre | styling.BlockPreEnd,
 			},
 			{
 				Token: styling.Token{
@@ -113,20 +114,20 @@ and two`,
 				Token: styling.Token{
 					Data: []byte("````\n"),
 					Info: []byte("`"),
-					Mask: styling.BlockPre | styling.BlockPreStart,
 				},
+				Mask: styling.BlockPre | styling.BlockPreStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("a\n"),
-					Mask: styling.BlockPre,
 				},
+				Mask: styling.BlockPre,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("```"),
-					Mask: styling.BlockPre | styling.BlockPreEnd,
 				},
+				Mask: styling.BlockPre | styling.BlockPreEnd,
 			},
 		},
 	},
@@ -137,14 +138,14 @@ and two`,
 			{
 				Token: styling.Token{
 					Data: []byte("```\n"),
-					Mask: styling.BlockPre | styling.BlockPreStart,
 				},
+				Mask: styling.BlockPre | styling.BlockPreStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("a```"),
-					Mask: styling.BlockPre,
 				},
+				Mask: styling.BlockPre,
 			},
 		},
 	},
@@ -156,8 +157,8 @@ and two`,
 				Token: styling.Token{
 					Data: []byte("```newtoken\n"),
 					Info: []byte("newtoken"),
-					Mask: styling.BlockPre | styling.BlockPreStart,
 				},
+				Mask: styling.BlockPre | styling.BlockPreStart,
 			},
 		},
 	},
@@ -169,21 +170,20 @@ not quoted`,
 			{
 				Token: styling.Token{
 					Data: []byte(">  "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("quoted\n"),
-					Mask: styling.BlockQuote,
 				},
+				Mask:  styling.BlockQuote,
 				Quote: 1,
 			},
 			{
-				Token: styling.Token{
-					Mask: styling.BlockQuote | styling.BlockQuoteEnd,
-				},
+				Token: styling.Token{},
+				Mask:  styling.BlockQuote | styling.BlockQuoteEnd,
 				Quote: 1,
 			},
 			{
@@ -204,62 +204,60 @@ not quoted`,
 			{
 				Token: styling.Token{
 					Data: []byte(">  "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("quoted\n"),
-					Mask: styling.BlockQuote,
 				},
+				Mask:  styling.BlockQuote,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte(">"),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte(">   "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 2,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("quote > 2\n"),
-					Mask: styling.BlockQuote,
 				},
+				Mask:  styling.BlockQuote,
 				Quote: 2,
 			},
 			{
-				Token: styling.Token{
-					Mask: styling.BlockQuote | styling.BlockQuoteEnd,
-				},
+				Token: styling.Token{},
+				Mask:  styling.BlockQuote | styling.BlockQuoteEnd,
 				Quote: 2,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte(">"),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("quote 1\n"),
-					Mask: styling.BlockQuote,
 				},
+				Mask:  styling.BlockQuote,
 				Quote: 1,
 			},
 			{
-				Token: styling.Token{
-					Mask: styling.BlockQuote | styling.BlockQuoteEnd,
-				},
+				Token: styling.Token{},
+				Mask:  styling.BlockQuote | styling.BlockQuoteEnd,
 				Quote: 1,
 			},
 			{
@@ -281,8 +279,8 @@ not quoted`,
 			{
 				Token: styling.Token{
 					Data: []byte("> "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 		},
@@ -297,57 +295,57 @@ not quoted`,
 			{
 				Token: styling.Token{
 					Data: []byte("> "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("```\n"),
-					Mask: styling.BlockQuote | styling.BlockPre | styling.BlockPreStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockPre | styling.BlockPreStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("> "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("pre\n"),
-					Mask: styling.BlockQuote | styling.BlockPre,
 				},
+				Mask:  styling.BlockQuote | styling.BlockPre,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("> "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("```\n"),
-					Mask: styling.BlockQuote | styling.BlockPre | styling.BlockPreEnd,
 				},
+				Mask:  styling.BlockQuote | styling.BlockPre | styling.BlockPreEnd,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("> "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("not pre"),
-					Mask: styling.BlockQuote,
 				},
+				Mask:  styling.BlockQuote,
 				Quote: 1,
 			},
 		},
@@ -361,36 +359,35 @@ plain`,
 			{
 				Token: styling.Token{
 					Data: []byte("> "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("``` \n"),
 					Info: []byte(" "),
-					Mask: styling.BlockQuote | styling.BlockPre | styling.BlockPreStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockPre | styling.BlockPreStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("> "),
-					Mask: styling.BlockQuote | styling.BlockQuoteStart,
 				},
+				Mask:  styling.BlockQuote | styling.BlockQuoteStart,
 				Quote: 1,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("pre\n"),
-					Mask: styling.BlockQuote | styling.BlockPre,
 				},
+				Mask:  styling.BlockQuote | styling.BlockPre,
 				Quote: 1,
 			},
 			{
-				Token: styling.Token{
-					Mask: styling.BlockQuote | styling.BlockQuoteEnd,
-				},
+				Token: styling.Token{},
+				Mask:  styling.BlockQuote | styling.BlockQuoteEnd,
 				Quote: 1,
 			},
 			{
@@ -407,20 +404,20 @@ plain`,
 			{
 				Token: styling.Token{
 					Data: []byte("*"),
-					Mask: styling.SpanStrong | styling.SpanStrongStart,
 				},
+				Mask: styling.SpanStrong | styling.SpanStrongStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("strong"),
-					Mask: styling.SpanStrong,
 				},
+				Mask: styling.SpanStrong,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("*"),
-					Mask: styling.SpanStrong | styling.SpanStrongEnd,
 				},
+				Mask: styling.SpanStrong | styling.SpanStrongEnd,
 			},
 			{
 				Token: styling.Token{
@@ -430,38 +427,38 @@ plain`,
 			{
 				Token: styling.Token{
 					Data: []byte("_"),
-					Mask: styling.SpanEmph | styling.SpanEmphStart,
 				},
+				Mask: styling.SpanEmph | styling.SpanEmphStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("emph"),
-					Mask: styling.SpanEmph,
 				},
+				Mask: styling.SpanEmph,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("_"),
-					Mask: styling.SpanEmph | styling.SpanEmphEnd,
 				},
+				Mask: styling.SpanEmph | styling.SpanEmphEnd,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("~"),
-					Mask: styling.SpanStrike | styling.SpanStrikeStart,
 				},
+				Mask: styling.SpanStrike | styling.SpanStrikeStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("strike"),
-					Mask: styling.SpanStrike,
 				},
+				Mask: styling.SpanStrike,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("~"),
-					Mask: styling.SpanStrike | styling.SpanStrikeEnd,
 				},
+				Mask: styling.SpanStrike | styling.SpanStrikeEnd,
 			},
 			{
 				Token: styling.Token{
@@ -471,20 +468,20 @@ plain`,
 			{
 				Token: styling.Token{
 					Data: []byte("`"),
-					Mask: styling.SpanPre | styling.SpanPreStart,
 				},
+				Mask: styling.SpanPre | styling.SpanPreStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("pre"),
-					Mask: styling.SpanPre,
 				},
+				Mask: styling.SpanPre,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("`"),
-					Mask: styling.SpanPre | styling.SpanPreEnd,
 				},
+				Mask: styling.SpanPre | styling.SpanPreEnd,
 			},
 		},
 	},
@@ -495,20 +492,20 @@ plain`,
 			{
 				Token: styling.Token{
 					Data: []byte("*"),
-					Mask: styling.SpanStrong | styling.SpanStrongStart,
 				},
+				Mask: styling.SpanStrong | styling.SpanStrongStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("strong"),
-					Mask: styling.SpanStrong,
 				},
+				Mask: styling.SpanStrong,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("*"),
-					Mask: styling.SpanStrong | styling.SpanStrongEnd,
 				},
+				Mask: styling.SpanStrong | styling.SpanStrongEnd,
 			},
 			{
 				Token: styling.Token{
@@ -529,20 +526,20 @@ plain`,
 			{
 				Token: styling.Token{
 					Data: []byte("*"),
-					Mask: styling.SpanStrong | styling.SpanStrongStart,
 				},
+				Mask: styling.SpanStrong | styling.SpanStrongStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("strong"),
-					Mask: styling.SpanStrong,
 				},
+				Mask: styling.SpanStrong,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("*"),
-					Mask: styling.SpanStrong | styling.SpanStrongEnd,
 				},
+				Mask: styling.SpanStrong | styling.SpanStrongEnd,
 			},
 		},
 	},
@@ -635,20 +632,20 @@ plain`,
 			{
 				Token: styling.Token{
 					Data: []byte("*"),
-					Mask: styling.SpanStrong | styling.SpanStrongStart,
 				},
+				Mask: styling.SpanStrong | styling.SpanStrongStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("this cannot _overlap"),
-					Mask: styling.SpanStrong,
 				},
+				Mask: styling.SpanStrong,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("*"),
-					Mask: styling.SpanStrong | styling.SpanStrongEnd,
 				},
+				Mask: styling.SpanStrong | styling.SpanStrongEnd,
 			},
 			{
 				Token: styling.Token{
@@ -664,38 +661,38 @@ plain`,
 			{
 				Token: styling.Token{
 					Data: []byte("_"),
-					Mask: styling.SpanEmph | styling.SpanEmphStart,
 				},
+				Mask: styling.SpanEmph | styling.SpanEmphStart,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("no pre "),
-					Mask: styling.SpanEmph,
 				},
+				Mask: styling.SpanEmph,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("`"),
-					Mask: styling.SpanPre | styling.SpanPreStart | styling.SpanEmph,
 				},
+				Mask: styling.SpanPre | styling.SpanPreStart | styling.SpanEmph,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("with *children*"),
-					Mask: styling.SpanPre | styling.SpanEmph,
 				},
+				Mask: styling.SpanPre | styling.SpanEmph,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("`"),
-					Mask: styling.SpanPre | styling.SpanPreEnd | styling.SpanEmph,
 				},
+				Mask: styling.SpanPre | styling.SpanPreEnd | styling.SpanEmph,
 			},
 			{
 				Token: styling.Token{
 					Data: []byte("_"),
-					Mask: styling.SpanEmph | styling.SpanEmphEnd,
 				},
+				Mask: styling.SpanEmph | styling.SpanEmphEnd,
 			},
 		},
 	},
@@ -720,8 +717,8 @@ func TestToken(t *testing.T) {
 
 				var expectedTok tokenAndStyle
 				expectedTok, toks = toks[0], toks[1:]
-				if expectedTok.Mask != tok.Mask {
-					t.Errorf("Unexpected mask for token %d: want=%#b, got=%#b", n, expectedTok.Mask, tok.Mask)
+				if style := d.Style(); expectedTok.Mask != style {
+					t.Errorf("Unexpected mask for token %d: want=%#b, got=%#b", n, expectedTok.Mask, style)
 				}
 				if !bytes.Equal(expectedTok.Data, tok.Data) {
 					t.Errorf("Unexpected data for token %d: want=%q, got=%q", n, expectedTok.Data, tok.Data)


### PR DESCRIPTION
Previously the current style was present on both tokens and the decoder,
leading to unnecessary duplication. Removing the style from individual
tokens makes the token stream re-orderable and reflects the fact that
styles aren't a property of individual tokens because changes to other
tokens earlier (or later) in the stream can affect tokens in the middle.

Fixes #129

Signed-off-by: Sam Whited <sam@samwhited.com>