### PR TITLE
styling: add ability to export styling tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 new.txt
 old.txt
 *.out
+styling_tests.json
 *.svg
 *.test
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,7 @@ styling/styling_string.go: styling/styling.go
 
 sessionstate_string.go: session.go
 	go generate
+
+styling_tests.json: styling/styling_test.go styling/export_test.go
+	go test -tags export ./styling -args -export=$@
+	mv styling/$@ .

--- a/styling/export_test.go
+++ b/styling/export_test.go
@@ -1,0 +1,78 @@
+// Copyright 2021 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+//go:build export
+// +build export
+
+package styling_test
+
+// This file is a tool that exports test data in JSON format for other libraries
+// and languages to use.
+// Running "go test -tags export" will cause the following TestMain function to
+// run which will spit out the tests to standard out.
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"mellium.im/xmpp/styling"
+)
+
+type jsonStyle struct {
+	Mask  styling.Style
+	Data  string
+	Info  string
+	Quote uint
+}
+
+type jsonTestCase struct {
+	Name   string
+	Input  string
+	Tokens []jsonStyle
+}
+
+func TestMain(m *testing.M) {
+	var outName = "decoder_tests.json"
+	flag.StringVar(&outName, "export", outName, "a filename to export JSON tests to")
+	flag.Parse()
+
+	fd, err := os.Create(outName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open file: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := fd.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close file: %v", err)
+			os.Exit(1)
+		}
+	}()
+
+	var jsonTestCases []jsonTestCase
+	for _, tc := range decoderTestCases {
+		newTC := jsonTestCase{
+			Name:  tc.name,
+			Input: tc.input,
+		}
+		for _, tok := range tc.toks {
+			newTC.Tokens = append(newTC.Tokens, jsonStyle{
+				Mask:  tok.Mask,
+				Data:  string(tok.Data),
+				Info:  string(tok.Info),
+				Quote: tok.Quote,
+			})
+		}
+		jsonTestCases = append(jsonTestCases, newTC)
+	}
+
+	e := json.NewEncoder(fd)
+	e.SetIndent("", "\t")
+	err = e.Encode(jsonTestCases)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/styling/styling_test.go
+++ b/styling/styling_test.go
@@ -44,7 +44,6 @@ var decoderTestCases = []struct {
 	name  string
 	input string
 	toks  []tokenAndStyle
-	Err   error
 }{
 	{
 		name:  "pre block start no newline backtick info string",
@@ -739,25 +738,8 @@ func TestToken(t *testing.T) {
 			}
 
 			err := d.Err()
-
-			switch err {
-			case nil:
-			case io.EOF:
-				if tc.Err != nil && tc.Err != io.EOF {
-					t.Errorf("Expected error but got io.EOF: %v", tc.Err)
-				}
-				if len(toks) != 0 {
-					var tokStrs []string
-					for _, tok := range toks {
-						tokStrs = append(tokStrs, string(tok.Data))
-					}
-					t.Fatalf("Reached EOF at token %d, but expected remaining tokens: %+v (%v)", n, tc.toks, tokStrs)
-				}
-				return
-			default:
-				if tc.Err != err {
-					t.Errorf("Unexpected error: want=%v, got=%v", tc.Err, err)
-				}
+			if err != io.EOF {
+				t.Errorf("unexpected error: want=%v, got=%v", io.EOF, err)
 			}
 		})
 	}


### PR DESCRIPTION
I keep exporting these tests in a rather manual way, so add a tool to do it so that we can easily export them when changes are made.