### PR TITLE
.builds: check each commit for DCO individually

### DIFF
--- a/.builds/validate.yml
+++ b/.builds/validate.yml
@@ -27,7 +27,7 @@ tasks:
 
       # Check that all commits that aren't in main are signed off by the same
       # committer (taken from the HEAD commit).
-      [[ ! "$(git log --invert-grep --grep="Signed-off-by: $(git show -s --pretty="%an <%ae>" HEAD)" origin/main..)" ]]
+      [[ ! "$(git log --pretty="%an <%ae>%n%(trailers:key=Signed-off-by,valueonly,separator=)" origin/main.. | uniq -u)" ]]
   - setup: |
       go version
       go env


### PR DESCRIPTION
Previously we checked commits based on the author in the HEAD commit,
but we need to use the author for the actual commit in case one patch set
contains commits by multiple authors.

Fixes #209

Signed-off-by: Sam Whited <sam@samwhited.com>