### PR TITLE
Minor fixes

### DIFF
--- a/disco/gen.go
+++ b/disco/gen.go
@@ -110,7 +110,7 @@ func genFile(regURL, tmpDir, outFile string, tmpl *template.Template) error {
 	if err != nil {
 		return err
 	}
-	defer fd.Close()
+	defer out.Close()
 
 	reg := registry{}
 	d := xml.NewDecoder(fd)
@@ -128,15 +128,6 @@ func genFile(regURL, tmpDir, outFile string, tmpl *template.Template) error {
 	}
 	_, err = io.Copy(out, bytes.NewReader(b))
 	return err
-}
-
-type writeCloser struct {
-	io.Writer
-	closer func() error
-}
-
-func (f writeCloser) Close() error {
-	return f.closer()
 }
 
 // opens the provided registry URL (downloading it if it doesn't exist).

--- a/internal/genfeature/gen.go
+++ b/internal/genfeature/gen.go
@@ -89,13 +89,13 @@ func main() {
 
 	parsedTmpl, err := template.New("out").Parse(tmpl)
 	if err != nil {
-		log.Fatalf("erro parsing template: %v", err)
+		log.Fatalf("error parsing template: %v", err)
 	}
 
 	var buf bytes.Buffer
 	fd, err := os.Create(outFile)
 	if err != nil {
-		log.Fatalf("error creatng file %q: %v", outFile, err)
+		log.Fatalf("error creating file %q: %v", outFile, err)
 	}
 	err = parsedTmpl.Execute(&buf, struct {
 		Args     string


### PR DESCRIPTION
A few minor fixes to various packages. Typo fixes, dead code removal, and a broken file close that didn't actually matter as it's a rarely run tool that exits quickly without consuming resources anyways.