### PR TITLE
internal/genform: ignore gosec false positives

### DIFF
--- a/internal/genform/gen.go
+++ b/internal/genform/gen.go
@@ -232,6 +232,7 @@ func main() {
 // opens the provided registry URL (downloading it if it doesn't exist).
 func openOrDownload(catURL, tmpDir string) (*os.File, error) {
 	registryXML := filepath.Join(tmpDir, filepath.Base(catURL))
+	/* #nosec */
 	fd, err := os.Open(registryXML)
 	if err != nil {
 		fd, err = os.Create(registryXML)
@@ -239,6 +240,7 @@ func openOrDownload(catURL, tmpDir string) (*os.File, error) {
 			return nil, err
 		}
 		// If we couldn't open it for reading, attempt to download it.
+		/* #nosec */
 		resp, err := http.Get(catURL)
 		if err != nil {
 			return nil, err
@@ -247,6 +249,7 @@ func openOrDownload(catURL, tmpDir string) (*os.File, error) {
 		if err != nil {
 			return nil, err
 		}
+		/* #nosec */
 		resp.Body.Close()
 		_, err = fd.Seek(0, 0)
 		if err != nil {

--- a/muc/integration_test.go
+++ b/muc/integration_test.go
@@ -19,7 +19,6 @@ import (
 	"mellium.im/xmpp/disco/items"
 	"mellium.im/xmpp/internal/integration"
 	"mellium.im/xmpp/internal/integration/prosody"
-	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/muc"
 	"mellium.im/xmpp/mux"

--- a/muc/room_integration_test.go
+++ b/muc/room_integration_test.go
@@ -17,7 +17,6 @@ import (
 	"mellium.im/xmpp"
 	"mellium.im/xmpp/internal/integration"
 	"mellium.im/xmpp/internal/integration/prosody"
-	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/jid"
 	"mellium.im/xmpp/muc"
 	"mellium.im/xmpp/mux"

--- a/ping/integration_test.go
+++ b/ping/integration_test.go
@@ -22,7 +22,6 @@ import (
 	"mellium.im/xmpp/internal/integration/mcabber"
 	"mellium.im/xmpp/internal/integration/prosody"
 	"mellium.im/xmpp/internal/integration/sendxmpp"
-	"mellium.im/xmpp/internal/ns"
 	"mellium.im/xmpp/mux"
 	"mellium.im/xmpp/ping"
 	"mellium.im/xmpp/stanza"


### PR DESCRIPTION
The gosec tool is complaining about several spots in gen.go, but this is
a tool that's only run on occasion by go generate and is not part of the
final build, making these issues safe.

Signed-off-by: Sam Whited <sam@samwhited.com>