### PR TITLE
carbons: add Private method

### DIFF
--- a/carbons/carbons.go
+++ b/carbons/carbons.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"io"
 
 	"mellium.im/xmlstream"
 	"mellium.im/xmpp"
@@ -112,39 +111,26 @@ func Unwrap(del *delay.Delay, r xml.TokenReader) (xml.TokenReader, xml.StartElem
 	return out, se, err
 }
 
-// Private is an xmlstream.Transformer that excludes a <message/> from being forwarded to
-// other Carbons-enabled resources, by adding a <private/> element and a <no-copy/> hint.
-// The first call to consume the output stream will return an error if the input stream
-// is not a message element with an appropriate namespace.
+// Private is an xmlstream.Transformer that excludes all top level <message/> elements from
+// being forwarded to other Carbons-enabled resources, by adding a <private/> element
+// and a <no-copy/> hint.
 func Private(r xml.TokenReader) xml.TokenReader {
-	token, err := r.Token()
-	if err != nil && err != io.EOF {
-		return xmlstream.ReaderFunc(func() (xml.Token, error) {
-			return token, err
-		})
-	}
-	se, ok := token.(xml.StartElement)
-	if !ok {
-		return xmlstream.ReaderFunc(func() (xml.Token, error) {
-			return token, fmt.Errorf("expected a startElement, found %T", token)
-		})
-	}
-	if se.Name.Local != "message" || (se.Name.Space != stanza.NSClient && se.Name.Space != stanza.NSServer) {
-		return xmlstream.ReaderFunc(func() (xml.Token, error) {
-			return token, fmt.Errorf("unexpected name for the message element: %+v", se.Name)
-		})
-	}
-
-	return xmlstream.Wrap(
-		xmlstream.MultiReader(
-			xmlstream.Inner(r),
-			xmlstream.Wrap(nil, xml.StartElement{
-				Name: xml.Name{Space: NS, Local: "private"},
-			}),
-			xmlstream.Wrap(nil, xml.StartElement{
-				Name: xml.Name{Space: "urn:xmpp:hints", Local: "no-copy"},
-			}),
-		),
-		se,
-	)
+	return xmlstream.InsertFunc(
+		func(start xml.StartElement, level uint64, w xmlstream.TokenWriter) error {
+			if level == 1 &&
+				start.Name.Local == "message" &&
+				(start.Name.Space == stanza.NSClient || start.Name.Space == stanza.NSServer) {
+				_, err := xmlstream.Copy(w, xmlstream.MultiReader(
+					xmlstream.Wrap(nil, xml.StartElement{
+						Name: xml.Name{Space: NS, Local: "private"},
+					}),
+					xmlstream.Wrap(nil, xml.StartElement{
+						Name: xml.Name{Space: "urn:xmpp:hints", Local: "no-copy"},
+					}),
+				))
+				return err
+			}
+			return nil
+		},
+	)(r)
 }


### PR DESCRIPTION
Private is an xmlstream.Transformer that excludes a `<message/>` from being forwarded to
other Carbons-enabled resources, by adding a `<private/>` element and a `<no-copy/>` hint.

See: https://github.com/mellium/xmpp/issues/157

Signed-off-by: TAKI MEKHALFA <takiedd.mekhalfa@gmail.com>