### PR TITLE
internal/genform: fix more gosec lints

### DIFF
--- a/.builds/validate.yml
+++ b/.builds/validate.yml
@@ -47,9 +47,7 @@ tasks:
       staticcheck -checks inherit,ST1000,ST1003,ST1016,ST1020,ST1021,ST1022,ST1023 ./...
       # gosec does not handle modules correctly.
       # See: https://github.com/securego/gosec/issues/622
-      # It also does not handle deferred close statements correctly (G307).
-      # See: https://github.com/securego/gosec/issues/714
-      gosec -exclude=G307 -exclude-dir=examples ./...
+      gosec -exclude-dir=examples ./...
 
       checkdoc -fileheader.pattern='-' ./... <<EOF
       Copyright \d\d\d\d The Mellium Contributors\.

--- a/internal/genform/gen.go
+++ b/internal/genform/gen.go
@@ -119,6 +119,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("error downloading (or opening) %s in %s: %v", regURL, tmpDir, err)
 	}
+	/* #nosec */
 	defer fd.Close()
 
 	reg := registry{}


### PR DESCRIPTION
Somehow we missed this one before, probably by running a different
version of gosec locally than we do in CI.
As with the others, this is just a small codegen tool and it is okay
that it uses unsafe constructs.

**EDIT:** this also reverts a disabled lint now that the bug has been fixed.