### PR TITLE
dial: Implement support for ALPN as per XEP-0368

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@
 // entry for yourself and regenerate this file by running make CONTRIBUTORS.
 // For more info see https://www.git-scm.com/docs/git-check-mailmap
 
+Ashish SHUKLA <ashish.is@lostca.se>
 Dane David <dndavid102@gmail.com>
 Julian Huhn <julian@huhn.dev>
 Michael Vetter <jubalh@iodoru.org>

--- a/dial/dial.go
+++ b/dial/dial.go
@@ -90,6 +90,12 @@ func (d *Dialer) dial(ctx context.Context, network string, addr jid.JID) (net.Co
 			ServerName: domain,
 			MinVersion: tls.VersionTLS12,
 		}
+		// XEP-0368
+		if d.S2S {
+			cfg.NextProtos = []string{"xmpp-server"}
+		} else {
+			cfg.NextProtos = []string{"xmpp-client"}
+		}
 	}
 	// If we're not looking up SRV records, use the A/AAAA fallback.
 	if d.NoLookup {


### PR DESCRIPTION
[XEP-0368](https://xmpp.org/extensions/xep-0368.html) states:

> 8. When ALPN is used, the ALPN protocol MUST be 'xmpp-client', where the SRV service is 'xmpps-client'.
> 9. When ALPN is used, the ALPN protocol MUST be 'xmpp-server', where the SRV service is 'xmpps-server'.

My XMPP server uses it with `nginx` listening on port 443, and [reverse proxying](https://nginx.org/en/docs/stream/ngx_stream_ssl_preread_module.html) to `ejabberd` when client specifies `xmpp-(client|server)`

Signed-off-by: Ashish SHUKLA <ashish.is@lostca.se>