### PR TITLE
all: move XML subset tracking into stream.Reader

### DIFF
--- a/blocklist/blocking_test.go
+++ b/blocklist/blocking_test.go
@@ -164,7 +164,7 @@ func TestFetch(t *testing.T) {
 func TestFetchNoStart(t *testing.T) {
 	cs := xmpptest.NewClientServer(
 		xmpptest.ServerHandlerFunc(func(e xmlstream.TokenReadEncoder, start *xml.StartElement) error {
-			const resp = `<iq id="123" type="result"><blocklist xmlns='urn:xmpp:blocklist'><!-- comment --></blocklist></iq>`
+			const resp = `<iq id="123" type="result"><blocklist xmlns='urn:xmpp:blocklist'></blocklist></iq>`
 			_, err := xmlstream.Copy(e, xml.NewDecoder(strings.NewReader(resp)))
 			return err
 		}),

--- a/disco/items_test.go
+++ b/disco/items_test.go
@@ -110,7 +110,7 @@ func TestFetchItemsNoStart(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			const resp = `<iq id="123" type="result"><query xmlns='http://jabber.org/protocol/disco#items'><!-- comment --></query></iq>`
+			const resp = `<iq id="123" type="result"><query xmlns='http://jabber.org/protocol/disco#items'></query></iq>`
 			_, err = xmlstream.Copy(e, xml.NewDecoder(strings.NewReader(resp)))
 			return err
 		}),

--- a/roster/roster_test.go
+++ b/roster/roster_test.go
@@ -84,7 +84,7 @@ func TestFetch(t *testing.T) {
 func TestFetchNoStart(t *testing.T) {
 	cs := xmpptest.NewClientServer(
 		xmpptest.ServerHandlerFunc(func(e xmlstream.TokenReadEncoder, start *xml.StartElement) error {
-			const resp = `<iq id="123" type="result"><query xmlns='jabber:iq:roster'><!-- comment --></query></iq>`
+			const resp = `<iq id="123" type="result"><query xmlns='jabber:iq:roster'></query></iq>`
 			_, err := xmlstream.Copy(e, xml.NewDecoder(strings.NewReader(resp)))
 			return err
 		}),

--- a/sasl_test.go
+++ b/sasl_test.go
@@ -148,7 +148,7 @@ var saslTestCases = [...]xmpptest.FeatureTestCase{
 	},
 	1: {
 		Feature: xmpp.SASL("", "", sasl.Plain),
-		In:      `<!-- not a start element -->`,
+		In:      "\t \n",
 		Out:     `<auth xmlns="urn:ietf:params:xml:ns:xmpp-sasl" mechanism="PLAIN">AHRlc3QA</auth>`,
 		Err:     xmpp.ErrUnexpectedPayload,
 	},
@@ -177,7 +177,7 @@ var saslTestCases = [...]xmpptest.FeatureTestCase{
 	5: {
 		State:   xmpp.Received,
 		Feature: xmpp.SASLServer(panicPerms, sasl.Plain),
-		In:      `<!-- not a start element -->`,
+		In:      "\t",
 		Err:     xmpp.ErrUnexpectedPayload,
 	},
 	6: {

--- a/session.go
+++ b/session.go
@@ -7,7 +7,6 @@
 package xmpp
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/xml"
@@ -500,11 +499,6 @@ func handleInputStream(s *Session, handler Handler) (err error) {
 	case xml.StartElement:
 		start = t
 	case xml.CharData:
-		if len(bytes.TrimLeft(t, " \t\r\n")) != 0 {
-			// Whitespace is allowed, but anything else at the top of the stream is
-			// disallowed.
-			return errors.New("xmpp: unexpected stream-level chardata")
-		}
 		return nil
 	default:
 		// If this isn't a start element or a whitespace keepalive, the stream is in


### PR DESCRIPTION
The stream.Reader transformer wraps every XML stream we pop from, so
moving the tracking of XML that is disallowed at the XMPP level into it
makes it easier to test and makes sure that these rules are enforced
consistently everywhere.

Fixes #126

Signed-off-by: Sam Whited <sam@samwhited.com>