### PR TITLE
internal/integration/aioxmpp: add new integration test package

### DIFF
--- a/.builds/integration.yml
+++ b/.builds/integration.yml
@@ -10,6 +10,7 @@ packages:
   # - mcabber
   - openssl
   - prosody
+  - python-pip
   - sendxmpp
 sources:
   - https://git.sr.ht/~samwhited/xmpp
@@ -19,6 +20,7 @@ tasks:
   - setup: |
       go version
       go env
+      pip --no-input install --no-warn-script-location aioxmpp
   - stable: |
       cd xmpp/
       go test -v -tags "integration" -run Integration ./...

--- a/internal/integration/aioxmpp/aioxmpp.go
+++ b/internal/integration/aioxmpp/aioxmpp.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+// Package aioxmpp facilitates integration testing against aioxmpp.
+//
+// Tests are accomplished by importing the automatically generated
+// aioxmpp_client Python package, subclassing the Daemon class, and overriding
+// the run method.
+// Other methods can also be overridden, in particular the prepare_argparse
+// method can be used to add command line arguments to the Python scripts.
+// For example:
+//
+//     from aioxmpp_client import Daemon
+//     import aioxmpp
+//
+//
+//     class Ping(Daemon):
+//         def prepare_argparse(self) -> None:
+//             super().prepare_argparse()
+//
+//             def jid(s):
+//                 return aioxmpp.JID.fromstr(s)
+//             self.argparse.add_argument(
+//                 "-j",
+//                 type=jid,
+//                 help="The JID to ping",
+//             )
+//
+//         async def run(self) -> None:
+//             await aioxmpp.ping.ping(self.client, self.args.j)
+//
+// For more information see aioxmpp_client.py and the aioxmpp documentation.
+package aioxmpp // import "mellium.im/xmpp/internal/integration/aioxmpp"
+
+import (
+	"context"
+	"io"
+	"testing"
+	"text/template"
+
+	"mellium.im/xmpp/internal/attr"
+	"mellium.im/xmpp/internal/integration"
+)
+
+const cmdName = "python"
+
+func getConfig(cmd *integration.Cmd) Config {
+	if cmd.Config == nil {
+		cmd.Config = Config{}
+	}
+	return cmd.Config.(Config)
+}
+
+func defaultConfig(cmd *integration.Cmd) error {
+	tmpl, err := template.New("aioxmpp").Parse(baseTest)
+	if err != nil {
+		return err
+	}
+
+	err = integration.TempFile(baseFileName, func(cmd *integration.Cmd, w io.Writer) error {
+		cfg := getConfig(cmd)
+		return tmpl.Execute(w, cfg)
+	})(cmd)
+	if err != nil {
+		return err
+	}
+
+	cfg := getConfig(cmd)
+	return integration.Args(append([]string{baseFileName}, cfg.Args...)...)(cmd)
+}
+
+// Import causes the given script to be written out to the working directory and the class name in that script to be
+// imported by the main testing runner and executed.
+func Import(class, script string) integration.Option {
+	return func(cmd *integration.Cmd) error {
+		fName := "tmp_" + attr.RandomID()
+		cfg := getConfig(cmd)
+		cfg.Imports = append(cfg.Imports, []string{fName, class})
+		cmd.Config = cfg
+		return integration.TempFile(fName+".py", func(cmd *integration.Cmd, w io.Writer) error {
+			_, err := io.WriteString(w, script)
+			return err
+		})(cmd)
+	}
+}
+
+// Args sets additional command line args to be passed to the script (ie. after the "aioxmpp_client.py" argument).
+// If you want to pass arguments to the python process (before the "aioxmpp_client.py" argument) use integration.Args.
+func Args(f ...string) integration.Option {
+	return func(cmd *integration.Cmd) error {
+		cfg := getConfig(cmd)
+		cfg.Args = append(cfg.Args, f...)
+		cmd.Config = cfg
+		return nil
+	}
+}
+
+// Test starts a the aioxmpp wrapper script and returns a function that runs
+// subtests using t.Run.
+// Multiple calls to the returned function will result in uniquely named
+// subtests.
+// When all subtests have completed, the daemon is stopped.
+func Test(ctx context.Context, t *testing.T, opts ...integration.Option) integration.SubtestRunner {
+	opts = append(opts, defaultConfig)
+	return integration.Test(ctx, cmdName, t, opts...)
+}

--- a/internal/integration/aioxmpp/aioxmpp_client.py
+++ b/internal/integration/aioxmpp/aioxmpp_client.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# Copyright 2022 The Mellium Contributors.
+# Use of this source code is governed by the BSD 2-clause
+# license that can be found in the LICENSE file.
+
+import abc
+import argparse
+import asyncio
+import configparser
+import sys
+
+import aioxmpp
+
+###
+# This script acts as a wrapper around aioxmpp that starts a simple client.
+# It is not meant to do any testing itself, instead use the Go aioxmpp.Import option to create a test script that
+# subclasses Daemon and overrides its run method.
+###
+
+
+class Daemon(metaclass=abc.ABCMeta):
+    def __init__(self) -> None:
+        super().__init__()
+        self.argparse: argparse.ArgumentParser = argparse.ArgumentParser()
+
+    def prepare_argparse(self) -> None:
+        self.argparse.add_argument(
+            "-c",
+            default="aioxmpp_config.ini",
+            type=argparse.FileType("r"),
+            help="The config file to load",
+        )
+
+    def configure(self):
+        self.args: argparse.Namespace = self.argparse.parse_args()
+        self.config: configparser.ConfigParser = configparser.ConfigParser()
+        self.config.read_file(self.args.c)
+        self.security: aioxmpp.security_layer.SecurityLayer = aioxmpp.make_security_layer(
+            self.config.get("client", "password"),
+            no_verify=True,
+        )
+        self.jid: aioxmpp.JID = aioxmpp.JID.fromstr(self.config.get("client", "jid"))
+        xmpp_port = self.config.getint("client", "port")
+        conn: aioxmpp.connector.BaseConnector = aioxmpp.connector.STARTTLSConnector()
+        self.client: aioxmpp.Client = aioxmpp.PresenceManagedClient(
+            self.jid,
+            self.security,
+            override_peer=[("127.0.0.1", xmpp_port, conn)],
+        )
+
+    async def run_test(self) -> None:
+        async with self.client.connected():
+            await self.run()
+
+    async def run(self) -> None:
+        raise NotImplementedError("test file must override run function")
+
+
+async def run_test(cls):
+    # We create the class in a wrapper function so that the aioxmpp.Client isn't created until after the event loop
+    # created by the call to asyncio.run is created. Otherwise the client creates its own event loop if one isn't
+    # already running and we end up trying to run things on the wrong loop.
+    instance = cls()
+    instance.prepare_argparse()
+    instance.configure()
+    await instance.run_test()
+
+if __name__ == "__main__":
+    print("running {{ len .Imports }} aioxmpp tests…")
+{{- range $idx, $script := .Imports }}
+    def runner():
+        from {{ index $script 0 }} import {{ index $script 1 }}
+        asyncio.run(run_test({{ index $script 1}}))
+    runner()
+    def runner():
+        from {{ index $script 0 }} import {{ index $script 1 }}
+        asyncio.run(run_test({{ index $script 1}}))
+    runner()
+{{- end }}

--- a/internal/integration/aioxmpp/aioxmpp_config.ini
+++ b/internal/integration/aioxmpp/aioxmpp_config.ini
@@ -1,0 +1,4 @@
+[client]
+jid       = {{.JID}}
+password  = {{.Password}}
+port      = {{.Port}}

--- a/internal/integration/aioxmpp/config.go
+++ b/internal/integration/aioxmpp/config.go
@@ -1,0 +1,67 @@
+// Copyright 2022 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package aioxmpp
+
+import (
+	_ "embed"
+	"io"
+	"path/filepath"
+	"text/template"
+
+	"mellium.im/xmpp/internal/integration"
+	"mellium.im/xmpp/jid"
+)
+
+const (
+	baseFileName = "aioxmpp_client.py"
+	cfgFileName  = "aioxmpp_config.ini"
+	cfgFlag      = "-c"
+)
+
+var (
+	//go:embed aioxmpp_config.ini
+	cfgBase string
+
+	//go:embed aioxmpp_client.py
+	baseTest string
+)
+
+// Config contains options that can be written to the config file.
+type Config struct {
+	JID      jid.JID
+	Password string
+	Port     string
+	Imports  [][]string
+	Args     []string
+}
+
+// ConfigFile is an option that can be used to write a temporary config file.
+// This will overwrite the existing config file and make most of the other
+// options in this package noops.
+// This option only exists for the rare occasion that you need complete control
+// over the config file.
+func ConfigFile(cfg Config) integration.Option {
+	cfgTmpl := template.Must(template.New("cfg").Parse(cfgBase))
+
+	return func(cmd *integration.Cmd) error {
+		cmd.Config = cfg
+		err := integration.TempFile(cfgFileName, func(cmd *integration.Cmd, w io.Writer) error {
+			return cfgTmpl.Execute(w, struct {
+				Config
+				ConfigDir string
+			}{
+				Config:    cfg,
+				ConfigDir: cmd.ConfigDir(),
+			})
+		})(cmd)
+		if err != nil {
+			return err
+		}
+		_ = filepath.Join
+		//cfgFilePath := filepath.Join(cmd.ConfigDir(), cfgFileName)
+		//return integration.Args(cfgFlag, cfgFilePath)(cmd)
+		return nil
+	}
+}

--- a/ping/aioxmpp_integration_test.py
+++ b/ping/aioxmpp_integration_test.py
@@ -1,0 +1,22 @@
+# Copyright 2022 The Mellium Contributors.
+# Use of this source code is governed by the BSD 2-clause
+# license that can be found in the LICENSE file.
+
+from aioxmpp_client import Daemon
+import aioxmpp
+
+
+class Ping(Daemon):
+    def prepare_argparse(self) -> None:
+        super().prepare_argparse()
+
+        def jid(s):
+            return aioxmpp.JID.fromstr(s)
+        self.argparse.add_argument(
+            "-j",
+            type=jid,
+            help="The JID to ping",
+        )
+
+    async def run(self) -> None:
+        await aioxmpp.ping.ping(self.client, self.args.j)


### PR DESCRIPTION
Add a new package for running integration tests against the [`aioxmpp`] Python library.

[`aioxmpp`]: https://docs.zombofant.net/aioxmpp/devel/