### PR TITLE
ibb: add new package implementing in-band bytestreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
   [XEP-0163: Personal Eventing Protocol]
 - carbons: add `WrapReceived` and `WrapSent` functions
 - forward: add `Unwrap` function
+- ibb: new package implementing [XEP-0047: In-Band Bytestreams]
 - stanza: add `NSError`, `NSClient`, and `NSServer` constants
 
 
@@ -26,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - mux: unhandled IQ result stanzas with no payload no longer result in an error
 - mux: responses are no longer sent for unhandled IQ result stanzas
 
+[XEP-0047: In-Band Bytestreams]: https://xmpp.org/extensions/xep-0047.html
 [XEP-0060: Publish-Subscribe]: https://xmpp.org/extensions/xep-0060.html
 [XEP-0163: Personal Eventing Protocol]: https://xmpp.org/extensions/xep-0163.html
 

--- a/ibb/aioxmpp_integration_test.py
+++ b/ibb/aioxmpp_integration_test.py
@@ -1,0 +1,132 @@
+# Copyright 2022 The Mellium Contributors.
+# Use of this source code is governed by the BSD 2-clause
+# license that can be found in the LICENSE file.
+
+import asyncio
+import sys
+
+from aioxmpp_client import Daemon
+from aioxmpp import ibb, JID
+from aioxmpp import Message
+from aioxmpp import MessageType
+from aioxmpp import xso
+from aioxmpp import IQ
+from aioxmpp.utils import namespaces
+
+#import logging
+#logging.basicConfig(level=logging.DEBUG)
+
+class TestProtocol(asyncio.Protocol):
+
+    def __init__(self):
+        self.data = b""
+        self.transport = None
+        self.closed_fut = asyncio.Future()
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def connection_lost(self, e):
+        self.closed_fut.set_result(e)
+
+    def pause_writing(self):
+        pass
+
+    def resume_writing(self):
+        pass
+
+    def data_received(self, data):
+        self.data += data
+
+
+class StartIBB(xso.XSO):
+    # When we're ready for the Go side to send an IBB open request we send <startibb/> as a way to give the Go side the
+    # JID we negotiated and let it know that we're ready to receive it.
+    TAG = (namespaces.client, "startibb")
+
+
+class DoneIBB(xso.XSO):
+    # When we finish receiving data over IBB we send it to the Go side via a message with the <doneibb/> payload and the
+    # data in the <body/>. This way the Go side can do the comparison and see if it matches what was expected.
+    TAG = (namespaces.client, "doneibb")
+
+
+class SendIBB(Daemon):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def prepare_argparse(self) -> None:
+        super().prepare_argparse()
+
+        def jid(s):
+            return JID.fromstr(s)
+        self.argparse.add_argument(
+            "-j",
+            type=jid,
+            help="The JID to start an IBB session with",
+        )
+
+    async def run(self) -> None:
+        service = ibb.IBBService(self.client)
+
+        transport: ibb.service.IBBTransport
+        protocol: asyncio.Protocol
+        transport, protocol = await service.open_session(TestProtocol, self.args.j)
+        transport.write("Warren snores through the night like a bear—a bass to the treble of the loons.".encode('utf-8'))
+        transport.close()
+        e = await protocol.closed_fut
+        if e is not None:
+            print(f'error awaiting connection close: {e}', file=sys.stderr)
+            sys.exit(1)
+        # Echo the data we read back so that the other side can confirm that what it sent is what was received.
+        msg = Message(to=self.args.j, type_=MessageType.NORMAL)
+        msg.body[None] = protocol.data.decode('utf-8')
+        msg.doneibb = DoneIBB()
+        await self.client.send(msg)
+
+
+class RecvIBB(Daemon):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def prepare_argparse(self) -> None:
+        super().prepare_argparse()
+
+        def jid(s):
+            return JID.fromstr(s)
+        self.argparse.add_argument(
+            "-j",
+            type=jid,
+            help="The JID to expect an IBB session from",
+        )
+        self.argparse.add_argument(
+            "-sid",
+            type=str,
+            help="The IBB session ID to expect",
+        )
+
+    async def run(self) -> None:
+        # First send the other side of the connection our JID so that it knows what JID to use.
+        msg = Message(to=self.args.j, type_=MessageType.NORMAL)
+        msg.startibb = StartIBB()
+        await self.client.send(msg)
+
+        service = ibb.IBBService(self.client)
+
+        transport: ibb.service.IBBTransport
+        protocol: asyncio.Protocol
+        transport, protocol = await service.expect_session(TestProtocol, self.args.j, self.args.sid)
+        transport.write(b"I feel a deep security in the single-mindedness of freight trains.")
+        e = await protocol.closed_fut
+        if e is not None:
+            print(f'error awaiting connection close: {e}', file=sys.stderr)
+            sys.exit(1)
+        # Echo the data we read back so that the other side can confirm that what it sent is what was received.
+        msg = Message(to=self.args.j, type_=MessageType.NORMAL)
+        msg.body[None] = protocol.data.decode('utf-8')
+        msg.doneibb = DoneIBB()
+        e = await self.client.send(msg)
+
+
+Message.startibb = xso.Child([StartIBB])
+Message.doneibb = xso.Child([DoneIBB])

--- a/ibb/conn.go
+++ b/ibb/conn.go
@@ -1,0 +1,336 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package ibb
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp"
+	"mellium.im/xmpp/jid"
+	"mellium.im/xmpp/stanza"
+)
+
+type nopContextEncoder struct {
+	t xmlstream.Encoder
+}
+
+func (n nopContextEncoder) Encode(_ context.Context, v interface{}) error {
+	return n.t.Encode(v)
+}
+
+type stanzaWriter struct {
+	s             *xmpp.Session
+	t             xmlstream.Encoder
+	sid           string
+	acked         bool
+	seq           uint16
+	to            jid.JID
+	writeDeadline time.Time
+}
+
+func (w *stanzaWriter) Write(p []byte) (int, error) {
+	data := dataPayload{
+		Seq:  w.seq,
+		SID:  w.sid,
+		Data: p,
+	}
+
+	ctx := context.Background()
+	if !w.writeDeadline.IsZero() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, w.writeDeadline)
+		defer cancel()
+	}
+
+	var e interface {
+		Encode(context.Context, interface{}) error
+	} = w.s
+	if w.t != nil {
+		e = nopContextEncoder{w.t}
+	}
+
+	var err error
+	if w.acked {
+		err = e.Encode(ctx, dataIQ{
+			IQ: stanza.IQ{
+				Type: stanza.SetIQ,
+				To:   w.to,
+			},
+			Data: data,
+		})
+	} else {
+		err = e.Encode(ctx, dataMessage{
+			Message: stanza.Message{
+				To: w.to,
+			},
+			Data: data,
+		})
+	}
+	if err != nil {
+		return 0, err
+	}
+	w.seq++
+	return len(p), nil
+}
+
+// Conn is an IBB stream.
+// Writes to the stream are buffered up to the blocksize before being
+// transmitted.
+type Conn struct {
+	closeFlushFunc func() error
+	handler        *Handler
+	b64Reader      io.Reader
+	readBuf        *bytes.Buffer
+	readBufM       *sync.Mutex
+	writeLock      sync.Mutex
+	readDeadline   time.Time
+	s              *xmpp.Session
+	writeBuf       *bufio.Writer
+	seq            uint16
+	closed         bool
+	recv           *io.PipeWriter
+	stanzaWriter   *stanzaWriter
+}
+
+func newConn(h *Handler, s *xmpp.Session, iq openIQ, recv bool) *Conn {
+	var to jid.JID
+	if recv {
+		to = iq.IQ.From
+	} else {
+		to = iq.IQ.To
+	}
+	// Setup a buffered writer to write data to the remote entity using stanzas as
+	// a carrier.
+	stanzaWrite := &stanzaWriter{
+		sid:   iq.Open.SID,
+		acked: iq.Open.Stanza == "iq" || iq.Open.Stanza == "",
+		to:    to,
+		s:     s,
+	}
+	b64Writer := base64.NewEncoder(base64.StdEncoding, stanzaWrite)
+	blockSize := iq.Open.BlockSize
+	if blockSize == 0 {
+		blockSize = BlockSize
+	}
+	w := bufio.NewWriterSize(b64Writer, int(blockSize))
+
+	// Setup a buffered reader to handle any incoming data that has been decoded
+	// by a handler (the handler will write it to the pipe).
+	pipeReader, pipeWriter := io.Pipe()
+	b64Reader := base64.NewDecoder(base64.StdEncoding, pipeReader)
+	r := bytes.NewBuffer(make([]byte, 0, blockSize))
+	readBufM := &sync.Mutex{}
+	go func() {
+		for {
+			readBufM.Lock()
+
+			_, err := r.ReadFrom(b64Reader)
+			readBufM.Unlock()
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	return &Conn{
+		b64Reader:      b64Reader,
+		readBuf:        r,
+		readBufM:       readBufM,
+		s:              s,
+		writeBuf:       w,
+		closeFlushFunc: b64Writer.Close,
+		handler:        h,
+		recv:           pipeWriter,
+		stanzaWriter:   stanzaWrite,
+	}
+}
+
+// SID returns a unique session ID for the connection.
+func (c *Conn) SID() string {
+	return c.stanzaWriter.sid
+}
+
+// Stanza returns the carrier stanza type ("message" or "iq") for payloads
+// received by the IBB session.
+func (c *Conn) Stanza() string {
+	if c.stanzaWriter.acked {
+		return "iq"
+	}
+	return "message"
+}
+
+// Read reads data from the IBB stream.
+// Read can be made to time out and return an Error with Timeout() == true
+// after a fixed time limit; see SetDeadline and SetReadDeadline.
+func (c *Conn) Read(b []byte) (n int, err error) {
+	c.readBufM.Lock()
+	defer c.readBufM.Unlock()
+
+	// Read first from the buffer, but if that is empty block and read directly
+	// from the pipe.
+	return io.MultiReader(c.readBuf, c.b64Reader).Read(b)
+}
+
+// Write writes data to the IBB stream.
+// Write can be made to time out and return an Error with Timeout() == true
+// after a fixed time limit; see SetDeadline and SetWriteDeadline.
+func (c *Conn) Write(b []byte) (n int, err error) {
+	if c.closed {
+		return 0, io.EOF
+	}
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+
+	return c.writeBuf.Write(b)
+}
+
+// LocalAddr returns the local network address of the underlying XMPP session.
+func (c *Conn) LocalAddr() net.Addr {
+	return c.s.LocalAddr()
+}
+
+// RemoteAddr returns the remote network address of the IBB stream.
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.stanzaWriter.to
+}
+
+// Size returns the blocksize for the underlying buffer when writing to the IBB
+// stream.
+func (c *Conn) Size() int {
+	return c.writeBuf.Size()
+}
+
+// Flush writes any buffered data to the underlying io.Writer.
+// This may result in data transfer less than the block size.
+func (c *Conn) Flush() error {
+	return c.flush(nil)
+}
+
+func (c *Conn) flush(t xmlstream.Encoder) error {
+	if t == nil {
+		c.writeLock.Lock()
+		defer c.writeLock.Unlock()
+		return c.writeBuf.Flush()
+	}
+
+	c.stanzaWriter.t = t
+	return c.writeBuf.Flush()
+}
+
+// Close closes the connection.
+// Any blocked Read or Write operations will be unblocked and return errors.
+// If the write buffer contains data it will be flushed.
+func (c *Conn) Close() error {
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+
+	// Flush any remaining data to be written.
+	err := c.Flush()
+	if err != nil {
+		return err
+	}
+	err = c.closeFlushFunc()
+	if err != nil {
+		return err
+	}
+
+	respReadCloser, err := c.s.SendIQElement(context.TODO(), closePayload(c.stanzaWriter.sid), stanza.IQ{
+		To:   c.stanzaWriter.to,
+		Type: stanza.SetIQ,
+	})
+	if err != nil {
+		return err
+	}
+	err = respReadCloser.Close()
+	if err != nil {
+		return err
+	}
+
+	return c.recv.Close()
+}
+
+func (c *Conn) closeNoNotify(t xmlstream.Encoder) error {
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+
+	c.handler.rmStream(c.stanzaWriter.sid)
+
+	// Flush any remaining data to be written.
+	err := c.flush(t)
+	if err != nil {
+		return err
+	}
+
+	err = c.closeFlushFunc()
+	if err != nil {
+		return err
+	}
+
+	return c.recv.Close()
+}
+
+// closeError is called when we close the connection due to an error, eg. the
+// other side sent invalid base64 and we don't want to continue.
+// It removes the connection from tracking without flushing any remaining data
+// and without communicating with the server.
+func (c *Conn) closeError() error {
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	c.handler.rmStream(c.stanzaWriter.sid)
+
+	return c.recv.Close()
+}
+
+// SetDeadline sets the read and write deadlines associated with the connection.
+// It is equivalent to calling both SetReadDeadline and SetWriteDeadline.
+//
+// A deadline is an absolute time after which I/O operations
+// fail with a timeout (see type Error) instead of
+// blocking. The deadline applies to all future and pending
+// I/O, not just the immediately following call to Read or
+// Write. After a deadline has been exceeded, the connection
+// can be refreshed by setting a deadline in the future.
+//
+// An idle timeout can be implemented by repeatedly extending
+// the deadline after successful Read or Write calls.
+//
+// A zero value for t means I/O operations will not time out.
+func (c *Conn) SetDeadline(t time.Time) error {
+	c.readDeadline = t
+	c.stanzaWriter.writeDeadline = t
+	return nil
+}
+
+// SetReadDeadline sets the deadline for future Read calls and any
+// currently-blocked Read call.
+// A zero value for t means Read will not time out.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	c.readDeadline = t
+	return nil
+}
+
+// SetWriteDeadline sets the deadline for future Write calls
+// and any currently-blocked Write call.
+// Even if write times out, it may return n > 0, indicating that some of the
+// data was successfully written.
+// A zero value for t means Write will not time out.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	c.stanzaWriter.writeDeadline = t
+	return nil
+}

--- a/ibb/ibb.go
+++ b/ibb/ibb.go
@@ -1,0 +1,268 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+// Package ibb implements data transfer with XEP-0047: In-Band Bytestreams.
+//
+// In-band bytestreams (IBB) are a bidirectional data transfer mechanism that
+// can be used to send small files or transfer other low-bandwidth data.
+// Because IBB uses base64 encoding to send the binary data, it is extremely
+// inefficient and should only be used as a fallback or last resort.
+package ibb // import "mellium.im/xmpp/ibb"
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/xml"
+	"errors"
+	"sync"
+
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp"
+	"mellium.im/xmpp/internal/attr"
+	"mellium.im/xmpp/jid"
+	"mellium.im/xmpp/mux"
+	"mellium.im/xmpp/stanza"
+)
+
+// NS is the XML namespace used by IBB, provided as a convenience.
+const NS = `http://jabber.org/protocol/ibb`
+
+// BlockSize is the default block size used if an IBB stream is opened with no
+// block size set.
+// Because IBB base64 encodes the underlying data, the actual data transfered
+// per stanza will be roughly twice the blocksize.
+const BlockSize = 1 << 11
+
+// Handle is an option that registers a handler for all the correct stanza
+// types and payloads.
+func Handle(h *Handler) mux.Option {
+	data := xml.Name{Space: NS, Local: "data"}
+	return func(m *mux.ServeMux) {
+		mux.Message("", data, h)(m)
+		mux.IQ(stanza.SetIQ, data, h)(m)
+		mux.IQ(stanza.SetIQ, xml.Name{Space: NS, Local: "open"}, h)(m)
+		mux.IQ(stanza.SetIQ, xml.Name{Space: NS, Local: "close"}, h)(m)
+	}
+}
+
+// Handler is an xmpp.Handler that handles multiplexing of bidirectional IBB
+// streams.
+type Handler struct {
+	mu      sync.Mutex
+	streams map[string]*Conn
+	l       map[string]Listener
+}
+
+// Listen creates a listener that accepts incoming IBB requests.
+//
+// If a listener has already been created for the given session it is returned
+// unaltered.
+func (h *Handler) Listen(s *xmpp.Session) Listener {
+	addrStr := s.LocalAddr().String()
+	if h.l == nil {
+		h.l = make(map[string]Listener)
+	}
+	l, ok := h.l[addrStr]
+	if ok {
+		return l
+	}
+	l = Listener{
+		s: s,
+		h: h,
+		c: make(chan *Conn),
+	}
+	h.l[addrStr] = l
+	return l
+}
+
+// HandleMessage implements mux.MessageHandler.
+func (h *Handler) HandleMessage(msg stanza.Message, t xmlstream.TokenReadEncoder) error {
+	d := xml.NewTokenDecoder(t)
+	p := dataMessage{}
+	err := d.Decode(&p)
+	if err != nil {
+		return err
+	}
+	return handlePayload(h, msg, p.Data, nil)
+}
+
+// HandleIQ implements mux.IQHandler.
+func (h *Handler) HandleIQ(iq stanza.IQ, t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
+	switch start.Name.Local {
+	case "open":
+		d := xml.NewTokenDecoder(xmlstream.MultiReader(xmlstream.Token(*start), t))
+		p := openPayload{}
+		err := d.Decode(&p)
+		if err != nil {
+			return err
+		}
+		return handleOpen(h, openIQ{
+			IQ:   iq,
+			Open: p,
+		}, t)
+	case "close":
+		_, sid := attr.Get(start.Attr, "sid")
+		conn, ok := h.streams[sid]
+		if !ok {
+			_, err := xmlstream.Copy(t, iq.Error(stanza.Error{
+				Type:      stanza.Cancel,
+				Condition: stanza.ItemNotFound,
+			}))
+			return err
+		}
+		err := conn.closeNoNotify(t)
+		if err != nil {
+			return err
+		}
+		_, err = xmlstream.Copy(t, iq.Result(nil))
+		return err
+	case "data":
+		d := xml.NewTokenDecoder(xmlstream.MultiReader(xmlstream.Token(*start), t))
+		p := dataPayload{}
+		err := d.Decode(&p)
+		if err != nil {
+			return err
+		}
+		return handlePayload(h, iq, p, t)
+	}
+
+	// We understand that this is an IBB payload, but did not recognize the
+	// element name so send an error.
+	_, err := xmlstream.Copy(t, iq.Error(stanza.Error{
+		Type:      stanza.Modify,
+		Condition: stanza.FeatureNotImplemented,
+	}))
+	return err
+}
+
+func handleOpen(h *Handler, iq openIQ, e xmlstream.Encoder) error {
+	to := iq.To.String()
+	l, ok := h.l[to]
+	if !ok {
+		l, ok = h.l[""]
+	}
+	if !ok {
+		_, err := xmlstream.Copy(e, iq.Error(stanza.Error{
+			Type:      stanza.Cancel,
+			Condition: stanza.NotAcceptable,
+		}))
+		return err
+	}
+	_, err := xmlstream.Copy(e, iq.Result(nil))
+	if err != nil {
+		return err
+	}
+	conn := newConn(h, l.s, iq, true)
+	h.addStream(iq.Open.SID, conn)
+	l.c <- conn
+	return nil
+}
+
+type errorResponder interface {
+	Error(stanza.Error) xml.TokenReader
+}
+
+func handlePayload(h *Handler, errResp errorResponder, p dataPayload, e xmlstream.Encoder) error {
+	conn, ok := h.streams[p.SID]
+	if !ok {
+		_, err := xmlstream.Copy(e, errResp.Error(stanza.Error{
+			Type:      stanza.Cancel,
+			Condition: stanza.ItemNotFound,
+		}))
+		return err
+	}
+
+	if p.Seq != conn.seq {
+		_, err := xmlstream.Copy(e, errResp.Error(stanza.Error{
+			Type:      stanza.Cancel,
+			Condition: stanza.UnexpectedRequest,
+		}))
+		return err
+	}
+	conn.seq++
+
+	iq, ok := errResp.(stanza.IQ)
+	if e != nil && ok {
+		_, err := xmlstream.Copy(e, iq.Result(nil))
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := conn.recv.Write(p.Data)
+	var inputErr base64.CorruptInputError
+	if errors.As(err, &inputErr) {
+		_, err := xmlstream.Copy(e, errResp.Error(stanza.Error{
+			Type:      stanza.Cancel,
+			Condition: stanza.BadRequest,
+		}))
+		if err != nil {
+			return err
+		}
+		return conn.closeError()
+	}
+	return err
+}
+
+// Open attempts to create a new IBB stream on the provided session.
+func (h *Handler) Open(ctx context.Context, s *xmpp.Session, to jid.JID) (*Conn, error) {
+	sid := attr.RandomID()
+	return open(ctx, h, true, s, stanza.IQ{To: to}, 0, sid)
+}
+
+// OpenIQ is like Open except that it allows you to customize the IQ and other
+// properties of the session initialization.
+// Changing the type of the IQ has no effect.
+func (h *Handler) OpenIQ(ctx context.Context, iq stanza.IQ, s *xmpp.Session, ack bool, blockSize uint16, sid string) (*Conn, error) {
+	return open(ctx, h, ack, s, iq, blockSize, sid)
+}
+
+func open(ctx context.Context, h *Handler, acked bool, s *xmpp.Session, start stanza.IQ, blockSize uint16, sid string) (*Conn, error) {
+	iq := openIQ{
+		IQ: start,
+	}
+	iq.Type = stanza.SetIQ
+	iq.Open.SID = sid
+	if acked {
+		iq.Open.Stanza = "iq"
+	} else {
+		iq.Open.Stanza = "message"
+	}
+	if blockSize == 0 {
+		iq.Open.BlockSize = BlockSize
+	} else {
+		iq.Open.BlockSize = blockSize
+	}
+
+	resp, err := s.SendIQ(ctx, iq.TokenReader())
+	if err != nil {
+		return nil, err
+	}
+	/* #nosec */
+	defer resp.Close()
+
+	conn, err := newConn(h, s, iq, false), nil
+	if err != nil {
+		return nil, err
+	}
+	h.addStream(sid, conn)
+	return conn, nil
+}
+
+func (h *Handler) addStream(sid string, conn *Conn) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.streams == nil {
+		h.streams = make(map[string]*Conn)
+	}
+	h.streams[sid] = conn
+}
+
+func (h *Handler) rmStream(sid string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	delete(h.streams, sid)
+}

--- a/ibb/integration_test.go
+++ b/ibb/integration_test.go
@@ -1,0 +1,219 @@
+// Copyright 2022 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+//go:build integration
+// +build integration
+
+package ibb_test
+
+import (
+	"context"
+	"crypto/tls"
+	_ "embed"
+	"encoding/xml"
+	"io"
+	"testing"
+
+	"mellium.im/sasl"
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp"
+	"mellium.im/xmpp/ibb"
+	"mellium.im/xmpp/internal/attr"
+	"mellium.im/xmpp/internal/integration"
+	"mellium.im/xmpp/internal/integration/aioxmpp"
+	"mellium.im/xmpp/internal/integration/prosody"
+	"mellium.im/xmpp/jid"
+	"mellium.im/xmpp/mux"
+	"mellium.im/xmpp/stanza"
+)
+
+//go:embed aioxmpp_integration_test.py
+var ibbScript string
+
+func TestIntegrationIBB(t *testing.T) {
+
+	prosodyRun := prosody.Test(context.TODO(), t,
+		integration.Log(),
+		integration.LogXML(),
+		prosody.ListenC2S(),
+	)
+	prosodyRun(integrationAioxmpp)
+}
+
+func integrationAioxmpp(ctx context.Context, t *testing.T, cmd *integration.Cmd) {
+	p := cmd.C2SPort()
+	j, pass := cmd.User()
+
+	t.Run("send", func(t *testing.T) {
+		session, err := cmd.DialClient(ctx, j, t,
+			xmpp.StartTLS(&tls.Config{
+				InsecureSkipVerify: true,
+			}),
+			xmpp.SASL("", pass, sasl.Plain),
+			xmpp.BindResource(),
+		)
+		if err != nil {
+			t.Fatalf("error connecting: %v", err)
+		}
+		sid := attr.RandomID()
+		aioxmppRun := aioxmpp.Test(context.TODO(), t,
+			integration.Log(),
+			aioxmpp.ConfigFile(aioxmpp.Config{
+				JID:      j,
+				Password: pass,
+				Port:     p,
+			}),
+			aioxmpp.Import("RecvIBB", ibbScript),
+			aioxmpp.Args("-j", session.LocalAddr().String()),
+			aioxmpp.Args("-sid", sid),
+		)
+		aioxmppRun(integrationSend(session, sid))
+	})
+
+	t.Run("recv", func(t *testing.T) {
+		session, err := cmd.DialClient(ctx, j, t,
+			xmpp.StartTLS(&tls.Config{
+				InsecureSkipVerify: true,
+			}),
+			xmpp.SASL("", pass, sasl.Plain),
+			xmpp.BindResource(),
+		)
+		if err != nil {
+			t.Fatalf("error connecting: %v", err)
+		}
+		aioxmppRun := aioxmpp.Test(context.TODO(), t,
+			integration.Log(),
+			aioxmpp.ConfigFile(aioxmpp.Config{
+				JID:      j,
+				Password: pass,
+				Port:     p,
+			}),
+			aioxmpp.Import("SendIBB", ibbScript),
+			aioxmpp.Args("-j", session.LocalAddr().String()),
+		)
+		aioxmppRun(integrationRecv(session))
+	})
+}
+
+func integrationRecv(session *xmpp.Session) func(context.Context, *testing.T, *integration.Cmd) {
+	return func(ctx context.Context, t *testing.T, cmd *integration.Cmd) {
+		ibbHandler := &ibb.Handler{}
+		echo := make(chan string)
+		go func() {
+			m := mux.New(
+				stanza.NSClient,
+				ibb.Handle(ibbHandler),
+				mux.MessageFunc("", xml.Name{Local: "doneibb"}, func(msg stanza.Message, r xmlstream.TokenReadEncoder) error {
+					bodyMessage := struct {
+						stanza.Message
+						Body string `xml:"body"`
+					}{}
+					err := xml.NewTokenDecoder(r).Decode(&bodyMessage)
+					if err != nil {
+						return err
+					}
+					go func() {
+						echo <- bodyMessage.Body
+					}()
+					return nil
+				}),
+			)
+			err := session.Serve(m)
+			if err != nil {
+				t.Logf("error from serve: %v", err)
+			}
+		}()
+
+		ln := ibbHandler.Listen(session)
+
+		const (
+			recvData = "Warren snores through the night like a bear—a bass to the treble of the loons."
+			sendData = "It is the the stillness of a moose intending to appear."
+		)
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Fatalf("error accepting IBB connection: %v", err)
+		}
+		_, err = io.WriteString(conn, sendData)
+		if err != nil {
+			t.Fatalf("error writing on received connection: %v", err)
+		}
+		recv, err := io.ReadAll(conn)
+		if err != nil {
+			t.Fatalf("error receiving data from IBB session: %v", err)
+		}
+		if string(recv) != recvData {
+			t.Fatalf("read wrong data from other end of IBB proxy: want=%s, got=%s", recvData, recv)
+		}
+		sent := <-echo
+		if sent != sendData {
+			t.Fatalf("other end of IBB proxy read wrong data: want=%s, got=%s", sendData, sent)
+		}
+	}
+}
+
+func integrationSend(session *xmpp.Session, sid string) func(context.Context, *testing.T, *integration.Cmd) {
+	return func(ctx context.Context, t *testing.T, cmd *integration.Cmd) {
+		ibbHandler := &ibb.Handler{}
+		j := make(chan jid.JID)
+		echo := make(chan string)
+		go func() {
+			m := mux.New(
+				stanza.NSClient,
+				ibb.Handle(ibbHandler),
+				mux.MessageFunc("", xml.Name{Local: "startibb"}, func(msg stanza.Message, _ xmlstream.TokenReadEncoder) error {
+					j <- msg.From
+					return nil
+				}),
+				mux.MessageFunc("", xml.Name{Local: "doneibb"}, func(msg stanza.Message, r xmlstream.TokenReadEncoder) error {
+					bodyMessage := struct {
+						stanza.Message
+						Body string `xml:"body"`
+					}{}
+					err := xml.NewTokenDecoder(r).Decode(&bodyMessage)
+					if err != nil {
+						return err
+					}
+					go func() {
+						echo <- bodyMessage.Body
+					}()
+					return nil
+				}),
+			)
+			err := session.Serve(m)
+			if err != nil {
+				t.Logf("error from serve: %v", err)
+			}
+		}()
+
+		to := <-j
+		const (
+			sendData = "Getting up too early is a vice habitual in horned owls, stars, geese, and freight trains."
+			recvData = "I feel a deep security in the single-mindedness of freight trains."
+		)
+		conn, err := ibbHandler.OpenIQ(ctx, stanza.IQ{To: to}, session, true, 4096, sid)
+		if err != nil {
+			t.Fatalf("error establishing IBB session: %v", err)
+		}
+		_, err = io.WriteString(conn, sendData)
+		if err != nil {
+			t.Fatalf("error writing on received connection: %v", err)
+		}
+		err = conn.Close()
+		if err != nil {
+			t.Fatalf("error closing connection: %v", err)
+		}
+		recv, err := io.ReadAll(conn)
+		if err != nil {
+			t.Fatalf("error receiving data from IBB session: %v", err)
+		}
+		if string(recv) != recvData {
+			t.Fatalf("read wrong data from other end of IBB proxy: want=%s, got=%s", recvData, recv)
+		}
+		sent := <-echo
+		if sent != sendData {
+			t.Fatalf("other end of IBB proxy read wrong data: want=%s, got=%s", sendData, sent)
+		}
+	}
+}

--- a/ibb/listen.go
+++ b/ibb/listen.go
@@ -1,0 +1,46 @@
+// Copyright 2022 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package ibb
+
+import (
+	"errors"
+	"net"
+
+	"mellium.im/xmpp"
+)
+
+// Listener is an implementation of net.Listener that is used to accept
+// incoming IBB streams.
+type Listener struct {
+	s *xmpp.Session
+	h *Handler
+	c chan *Conn
+}
+
+// Accept waits for the next incoming IBB stream and returns the connection.
+// If the listener is closed by either end pending Accept calls unblock and
+// return an error.
+func (l Listener) Accept() (net.Conn, error) {
+	conn, ok := <-l.c
+	if !ok {
+		return nil, errors.New("ibb: accept on closed listener")
+	}
+	return conn, nil
+}
+
+// Close stops listening and causes any pending Accept calls to unblock and
+// return an error.
+// Already accepted connections are not closed.
+func (l Listener) Close() error {
+	delete(l.h.l, l.s.LocalAddr().String())
+	close(l.c)
+	return nil
+}
+
+// Addr returns the local address for which this listener is accepting
+// connections.
+func (l Listener) Addr() net.Addr {
+	return l.s.LocalAddr()
+}

--- a/ibb/payloads.go
+++ b/ibb/payloads.go
@@ -1,0 +1,84 @@
+// Copyright 2020 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package ibb
+
+import (
+	"encoding/xml"
+	"strconv"
+
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp/stanza"
+)
+
+func closePayload(sid string) xml.TokenReader {
+	return xmlstream.Wrap(nil, xml.StartElement{
+		Name: xml.Name{Space: NS, Local: "close"},
+		Attr: []xml.Attr{{
+			Name:  xml.Name{Local: "sid"},
+			Value: sid,
+		}},
+	})
+}
+
+type openPayload struct {
+	XMLName   xml.Name `xml:"http://jabber.org/protocol/ibb open"`
+	BlockSize uint16   `xml:"block-size,attr"`
+	SID       string   `xml:"sid,attr"`
+	Stanza    string   `xml:"stanza,attr,omitempty"`
+}
+
+type openIQ struct {
+	stanza.IQ
+
+	Open openPayload `xml:"http://jabber.org/protocol/ibb open"`
+}
+
+// WriteXML satisfies the xmlstream.WriterTo interface.
+// It is like MarshalXML except it writes tokens to w.
+func (iq openIQ) WriteXML(w xmlstream.TokenWriter) (n int, err error) {
+	return xmlstream.Copy(w, iq.TokenReader())
+}
+
+// TokenReader satisfies the xmlstream.Marshaler interface.
+func (iq openIQ) TokenReader() xml.TokenReader {
+	start := xml.StartElement{Name: xml.Name{Local: "open", Space: NS}}
+
+	start.Attr = make([]xml.Attr, 0, 3)
+	start.Attr = append(start.Attr, xml.Attr{
+		Name:  xml.Name{Local: "block-size"},
+		Value: strconv.FormatUint(uint64(iq.Open.BlockSize), 10),
+	})
+	start.Attr = append(start.Attr, xml.Attr{
+		Name:  xml.Name{Local: "sid"},
+		Value: iq.Open.SID,
+	})
+	if iq.Open.Stanza != "" {
+		start.Attr = append(start.Attr, xml.Attr{
+			Name:  xml.Name{Local: "stanza"},
+			Value: string(iq.Open.Stanza),
+		})
+	}
+
+	return iq.Wrap(xmlstream.Wrap(nil, start))
+}
+
+type dataPayload struct {
+	XMLName xml.Name `xml:"http://jabber.org/protocol/ibb data"`
+	Seq     uint16   `xml:"seq,attr"`
+	SID     string   `xml:"sid,attr"`
+	Data    []byte   `xml:",chardata"`
+}
+
+type dataIQ struct {
+	stanza.IQ
+
+	Data dataPayload `xml:"http://jabber.org/protocol/ibb data"`
+}
+
+type dataMessage struct {
+	stanza.Message
+
+	Data dataPayload `xml:"http://jabber.org/protocol/ibb data"`
+}

--- a/internal/genform/gen.go
+++ b/internal/genform/gen.go
@@ -236,6 +236,7 @@ func openOrDownload(catURL, tmpDir string) (*os.File, error) {
 	/* #nosec */
 	fd, err := os.Open(registryXML)
 	if err != nil {
+		/* #nosec */
 		fd, err = os.Create(registryXML)
 		if err != nil {
 			return nil, err

--- a/internal/integration/mcabber/mcabber.go
+++ b/internal/integration/mcabber/mcabber.go
@@ -100,6 +100,7 @@ func defaultConfig(cmd *integration.Cmd) error {
 	if err != nil {
 		return err
 	}
+	/* #nosec */
 	fd, err := os.Create(logFilePath)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is the initial stages of support for [XEP-0047: In-Band Bytestreams]. For more information, see the [design doc].

Fixes #19

[XEP-0047: In-Band Bytestreams]: https://xmpp.org/extensions/xep-0047.html
[design doc]: https://mellium.im/design/19_ibb