### PR TITLE
xmpp: write error IQ responses correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to this project will be documented in this file.
 - forward: add `Unwrap` function
 - stanza: add `NSError`, `NSClient`, and `NSServer` constants
 
+
+### Fixed
+
+- xmpp: IQ error responses are now sent to the original entity, not to
+  ourselves
+
 [XEP-0060: Publish-Subscribe]: https://xmpp.org/extensions/xep-0060.html
 [XEP-0163: Personal Eventing Protocol]: https://xmpp.org/extensions/xep-0163.html
 

--- a/session.go
+++ b/session.go
@@ -560,10 +560,10 @@ func handleInputStream(s *Session, handler Handler) (err error) {
 	iqNeedsResp := typ == string(stanza.GetIQ) || typ == string(stanza.SetIQ)
 	// If the user did not write a response to an IQ, send a default one.
 	if iqOk && iqNeedsResp && !rw.wroteResp {
-		_, toAttr := attr.Get(start.Attr, "to")
+		_, fromAttr := attr.Get(start.Attr, "from")
 		var to jid.JID
-		if toAttr != "" {
-			to, err = jid.Parse(toAttr)
+		if fromAttr != "" {
+			to, err = jid.Parse(fromAttr)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
While working on IBB tests the other side of the connection sent us a
payload we don't support, resulting in an error. However, I noticed the
error was showing up in the logs twice: once being sent and once being
received. It turns out we have been sending errors to ourselves instead
of the remote entity. This patch fixes that.

Signed-off-by: Sam Whited <sam@samwhited.com>