### PR TITLE
internal/integration/aioxmpp: run tests only once

### DIFF
--- a/internal/integration/aioxmpp/aioxmpp_client.py
+++ b/internal/integration/aioxmpp/aioxmpp_client.py
@@ -72,8 +72,4 @@ if __name__ == "__main__":
         from {{ index $script 0 }} import {{ index $script 1 }}
         asyncio.run(run_test({{ index $script 1}}))
     runner()
-    def runner():
-        from {{ index $script 0 }} import {{ index $script 1 }}
-        asyncio.run(run_test({{ index $script 1}}))
-    runner()
 {{- end }}


### PR DESCRIPTION
Somehow I copy/pasted and duplicated the test runner code, but we
probably only want to run the Python side of tests once.

Signed-off-by: Sam Whited <sam@samwhited.com>