### PR TITLE
mux: fix several small bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 - xmpp: IQ error responses are now sent to the original entity, not to
   ourselves
 - xmpp: the mux package no longer errors when encountering empty IQ stanzas
+- mux: responses are no longer sent for unhandled IQ result stanzas
+
 
 [XEP-0060: Publish-Subscribe]: https://xmpp.org/extensions/xep-0060.html
 [XEP-0163: Personal Eventing Protocol]: https://xmpp.org/extensions/xep-0163.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 - xmpp: IQ error responses are now sent to the original entity, not to
   ourselves
+- xmpp: the mux package no longer errors when encountering empty IQ stanzas
 
 [XEP-0060: Publish-Subscribe]: https://xmpp.org/extensions/xep-0060.html
 [XEP-0163: Personal Eventing Protocol]: https://xmpp.org/extensions/xep-0163.html

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -536,7 +536,7 @@ func forChildren(m *ServeMux, stanzaVal interface{}, t xmlstream.TokenReadEncode
 }
 
 func iqFallback(iq stanza.IQ, t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
-	if iq.Type == stanza.ErrorIQ {
+	if iq.Type == stanza.ErrorIQ || iq.Type == stanza.ResultIQ {
 		return nil
 	}
 

--- a/mux/mux_test.go
+++ b/mux/mux_test.go
@@ -477,14 +477,28 @@ var testCases = [...]struct {
 		err: errPassTest,
 	},
 	42: {
-		// An empty IQ is illegal and should result in EOF.
+		// An empty IQ of type "get" is illegal and should result in an error.
 		m: []mux.Option{
 			mux.IQ(stanza.GetIQ, xml.Name{}, failHandler{}),
-			mux.IQ(stanza.SetIQ, xml.Name{}, failHandler{}),
-			mux.Presence(stanza.AvailablePresence, xml.Name{}, failHandler{}),
 		},
 		x:   `<iq xml:lang="en-us" type="get" xmlns="jabber:client"></iq>`,
 		err: io.EOF,
+	},
+	43: {
+		// An empty IQ of type "set" is illegal and should result in an error.
+		m: []mux.Option{
+			mux.IQ(stanza.SetIQ, xml.Name{}, failHandler{}),
+		},
+		x:   `<iq xml:lang="en-us" type="set" xmlns="jabber:client"></iq>`,
+		err: io.EOF,
+	},
+	44: {
+		// An empty IQ of type "result" is fine.
+		m: []mux.Option{
+			mux.IQ(stanza.ResultIQ, xml.Name{}, passHandler{}),
+		},
+		x:   `<iq xml:lang="en-us" type="result" xmlns="jabber:client"></iq>`,
+		err: errPassTest,
 	},
 }
 


### PR DESCRIPTION
These two patches fix two bugs in the `mux` package. The first fixes an edge case where we would respond to unhandled IQs of type "result" with a service-unavailable error, however we should never respond to result type IQs. The second fixes an issue where an unhandled result IQ with no payload would result in the stream being disconnected. However, this is a perfectly valid thing to send (only set, get, and error IQs require payloads).