### PR TITLE
ibb: simplify concurrency and fix data race

### DIFF
--- a/ibb/ibb_test.go
+++ b/ibb/ibb_test.go
@@ -1,0 +1,116 @@
+// Copyright 2022 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package ibb_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"mellium.im/xmpp/ibb"
+	"mellium.im/xmpp/internal/xmpptest"
+	"mellium.im/xmpp/mux"
+	"mellium.im/xmpp/stanza"
+)
+
+func TestSendSelf(t *testing.T) {
+	clientIBB := &ibb.Handler{}
+	serverIBB := &ibb.Handler{}
+	clientM := mux.New(
+		stanza.NSClient,
+		ibb.Handle(clientIBB),
+	)
+	serverM := mux.New(
+		stanza.NSClient,
+		ibb.Handle(serverIBB),
+	)
+	s := xmpptest.NewClientServer(
+		xmpptest.ClientHandler(clientM),
+		xmpptest.ServerHandler(serverM),
+	)
+
+	const (
+		iqPayload  = "There are two spiritual dangers in not owning a farm."
+		msgPayload = "One is the danger of supposing that breakfast comes from the grocery, and the other that heat comes from the furnace."
+	)
+	recv := make(chan struct {
+		Got string
+		Err error
+	})
+	go func() {
+		result := struct {
+			Got string
+			Err error
+		}{}
+
+		for {
+			select {
+			case <-recv:
+				return
+			default:
+			}
+			ln := serverIBB.Listen(s.Server)
+			serverConn, err := ln.Accept()
+			if err != nil {
+				result.Err = fmt.Errorf("error listening for conn: %w", err)
+				recv <- result
+				return
+			}
+			b, err := io.ReadAll(serverConn)
+			if err != nil {
+				result.Err = fmt.Errorf("error reading full payload: %w", err)
+				recv <- result
+				return
+			}
+			result.Got = string(b)
+			recv <- result
+		}
+	}()
+
+	t.Run("iq", func(t *testing.T) {
+		clientConn, err := clientIBB.Open(context.Background(), s.Client, s.Server.LocalAddr())
+		if err != nil {
+			t.Fatalf("error opening connection: %v", err)
+		}
+		_, err = io.WriteString(clientConn, iqPayload)
+		if err != nil {
+			t.Fatalf("error writing string: %v", err)
+		}
+		err = clientConn.Close()
+		if err != nil {
+			t.Fatalf("error closing conn: %v", err)
+		}
+		got := <-recv
+		if got.Err != nil {
+			t.Fatal(err)
+		}
+		if got.Got != iqPayload {
+			t.Errorf("got wrong payload type: want=%q, got=%q", iqPayload, got.Got)
+		}
+	})
+	t.Run("msg", func(t *testing.T) {
+		clientConn, err := clientIBB.OpenIQ(context.Background(), stanza.IQ{To: s.Server.LocalAddr()}, s.Client, false, 5, "1234")
+		if err != nil {
+			t.Fatalf("error opening connection: %v", err)
+		}
+		_, err = io.WriteString(clientConn, msgPayload)
+		if err != nil {
+			t.Fatalf("error writing string: %v", err)
+		}
+		err = clientConn.Close()
+		if err != nil {
+			t.Fatalf("error closing conn: %v", err)
+		}
+		got := <-recv
+		if got.Err != nil {
+			t.Fatal(err)
+		}
+		if got.Got != msgPayload {
+			t.Errorf("got wrong payload type: want=%q, got=%q", iqPayload, got.Got)
+		}
+	})
+	close(recv)
+}

--- a/ibb/integration_test.go
+++ b/ibb/integration_test.go
@@ -32,7 +32,6 @@ import (
 var ibbScript string
 
 func TestIntegrationIBB(t *testing.T) {
-
 	prosodyRun := prosody.Test(context.TODO(), t,
 		integration.Log(),
 		integration.LogXML(),

--- a/ibb/listen.go
+++ b/ibb/listen.go
@@ -34,6 +34,8 @@ func (l Listener) Accept() (net.Conn, error) {
 // return an error.
 // Already accepted connections are not closed.
 func (l Listener) Close() error {
+	l.h.lM.Lock()
+	defer l.h.lM.Unlock()
 	delete(l.h.l, l.s.LocalAddr().String())
 	close(l.c)
 	return nil


### PR DESCRIPTION
This greatly simplifies the concurrency of IBB and fixes a race condition when creating, destroying, and using listeners.