### PR TITLE
examples/msgrepl: fix crash for empty input

### DIFF
--- a/examples/msgrepl/main.go
+++ b/examples/msgrepl/main.go
@@ -144,7 +144,7 @@ func main() {
 
 		msg := userInput.Text()
 		if msg == "" {
-			return
+			continue
 		}
 
 		if msg == "help" {


### PR DESCRIPTION
Inside the for loop is a return statement that causes msgrepl to crash
if the user makes an empty input. Replace return with continue.

Signed-off-by: Julian Huhn <julian@huhn.dev>