### PR TITLE
ping: run integration tests against slixmpp

### DIFF
--- a/.builds/integration.yml
+++ b/.builds/integration.yml
@@ -12,14 +12,22 @@ packages:
   - prosody
   - python-pip
   - sendxmpp
+  # We cannot use a released version of Slixmpp because no released version
+  # currently supports Python 3.10 or greater.
+  # See: https://lab.louiz.org/poezio/slixmpp/-/issues/3467
+  - python-slixmpp-git
 sources:
   - https://git.sr.ht/~samwhited/xmpp
 environment:
   GO111MODULE: "on"
 tasks:
   - setup: |
+      python --version
       go version
       go env
+      # Install via pip instead of the AUR because otherwise tests are run and
+      # fail with:
+      # AttributeError: 'datetime.timezone' object has no attribute 'normalize'
       pip --no-input install --no-warn-script-location aioxmpp
   - stable: |
       cd xmpp/

--- a/ping/slixmpp_integration_test.py
+++ b/ping/slixmpp_integration_test.py
@@ -1,0 +1,24 @@
+# Copyright 2022 The Mellium Contributors.
+# Use of this source code is governed by the BSD 2-clause
+# license that can be found in the LICENSE file.
+
+from slixmpp_client import Daemon
+import slixmpp
+
+
+class Ping(Daemon):
+    def prepare_argparse(self) -> None:
+        super().prepare_argparse()
+
+        self.argparse.add_argument(
+            "-j",
+            type=slixmpp.jid.JID,
+            help="The JID to ping",
+        )
+
+    def configure(self):
+        super().configure()
+        self.client.register_plugin('xep_0199') # Ping
+
+    async def run(self) -> None:
+        await self.client.plugin['xep_0199'].ping(jid=self.args.j)


### PR DESCRIPTION
This is the first attempt to test out the new slixmpp integration testing. As always, we start with the trusty (and dead simple) ping package.