### PR TITLE
internal/integration: allow renaming subtests

### DIFF
--- a/internal/integration/aioxmpp/aioxmpp.go
+++ b/internal/integration/aioxmpp/aioxmpp.go
@@ -66,6 +66,11 @@ func defaultConfig(cmd *integration.Cmd) error {
 		return err
 	}
 
+	err = integration.Name("aioxmpp")(cmd)
+	if err != nil {
+		return err
+	}
+
 	return integration.TempFile(baseFileName, func(cmd *integration.Cmd, w io.Writer) error {
 		cfg := getConfig(cmd)
 		return tmpl.Execute(w, cfg)

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -732,6 +732,19 @@ func Defer(f func(*Cmd) error) Option {
 	}
 }
 
+// Name sets the name of the test.
+// This defaults to the basename of the path to the binary (ie. if the testing
+// binary is /usr/local/sbin/prosody the name of the test will be "prosody").
+// It can be useful to override this when multiple tests run the same binary,
+// for example the aioxmpp and slixmpp package would both generate tests called
+// "python" if they did not provide this option.
+func Name(s string) Option {
+	return func(cmd *Cmd) error {
+		cmd.name = s
+		return nil
+	}
+}
+
 // Test starts a command and returns a function that runs tests as a subtest
 // using t.Run.
 // Multiple calls to the returned function will result in uniquely named
@@ -760,7 +773,7 @@ func Test(ctx context.Context, name string, t *testing.T, opts ...Option) Subtes
 	if cmd.skip {
 		return func(f func(context.Context, *testing.T, *Cmd)) bool {
 			i++
-			return t.Run(fmt.Sprintf("%s/%d", filepath.Base(name), i), func(t *testing.T) {
+			return t.Run(fmt.Sprintf("%s/%d", filepath.Base(cmd.name), i), func(t *testing.T) {
 				t.Skip("skipping due to developer provided option")
 			})
 		}
@@ -800,7 +813,7 @@ func Test(ctx context.Context, name string, t *testing.T, opts ...Option) Subtes
 
 	return func(f func(context.Context, *testing.T, *Cmd)) bool {
 		i++
-		return t.Run(fmt.Sprintf("%s/%d", filepath.Base(name), i), func(t *testing.T) {
+		return t.Run(fmt.Sprintf("%s/%d", filepath.Base(cmd.name), i), func(t *testing.T) {
 			if tw, ok := cmd.Cmd.Stdout.(*testWriter); ok {
 				tw.Update(t)
 			}

--- a/internal/integration/slixmpp/slixmpp.go
+++ b/internal/integration/slixmpp/slixmpp.go
@@ -69,6 +69,11 @@ func defaultConfig(cmd *integration.Cmd) error {
 		return err
 	}
 
+	err = integration.Name("slixmpp")(cmd)
+	if err != nil {
+		return err
+	}
+
 	return integration.TempFile(baseFileName, func(cmd *integration.Cmd, w io.Writer) error {
 		cfg := getConfig(cmd)
 		return tmpl.Execute(w, cfg)


### PR DESCRIPTION
Also rename tests created with the aioxmpp and slixmpp packages from
"python" to "aioxmpp" and "slixmpp" respectively.

Signed-off-by: Sam Whited <sam@samwhited.com>