### PR TITLE
ibb: add max buffer size

### DIFF
--- a/ibb/integration_test.go
+++ b/ibb/integration_test.go
@@ -41,7 +41,6 @@ var (
 func TestIntegrationIBB(t *testing.T) {
 	prosodyRun := prosody.Test(context.TODO(), t,
 		integration.Log(),
-		integration.LogXML(),
 		prosody.ListenC2S(),
 	)
 	prosodyRun(integrationAioxmpp)

--- a/ibb/integration_test.go
+++ b/ibb/integration_test.go
@@ -40,7 +40,6 @@ var (
 
 func TestIntegrationIBB(t *testing.T) {
 	prosodyRun := prosody.Test(context.TODO(), t,
-		integration.Log(),
 		prosody.ListenC2S(),
 	)
 	prosodyRun(integrationAioxmpp)

--- a/ibb/payloads.go
+++ b/ibb/payloads.go
@@ -71,10 +71,27 @@ type dataPayload struct {
 	Data    []byte   `xml:",chardata"`
 }
 
+func (p dataPayload) TokenReader() xml.TokenReader {
+	return xmlstream.Wrap(
+		xmlstream.Token(xml.CharData(p.Data)),
+		xml.StartElement{
+			Name: xml.Name{Space: NS, Local: "data"},
+			Attr: []xml.Attr{
+				{Name: xml.Name{Local: "seq"}, Value: strconv.FormatUint(uint64(p.Seq), 10)},
+				{Name: xml.Name{Local: "sid"}, Value: p.SID},
+			},
+		},
+	)
+}
+
 type dataIQ struct {
 	stanza.IQ
 
 	Data dataPayload `xml:"http://jabber.org/protocol/ibb data"`
+}
+
+func (iq dataIQ) TokenReader() xml.TokenReader {
+	return iq.IQ.Wrap(iq.Data.TokenReader())
 }
 
 type dataMessage struct {

--- a/ibb/slixmpp_integration_test.py
+++ b/ibb/slixmpp_integration_test.py
@@ -11,7 +11,6 @@ import slixmpp
 class SendIBB(Daemon):
     def __init__(self) -> None:
         super().__init__()
-        self.data = bytearray()
 
     def prepare_argparse(self) -> None:
         super().prepare_argparse()
@@ -29,21 +28,18 @@ class SendIBB(Daemon):
     async def run(self) -> None:
         ibb = self.client.plugin['xep_0047']
 
-        self.client.add_event_handler(
-            "ibb_stream_data",
-            lambda stream: self.data.extend(stream.recv_queue.get_nowait()),
-        )
-
         conn = await ibb.open_stream(self.args.j)
         await conn.sendall("Warren snores through the night like a bear—a bass to the treble of the loons.".encode('utf-8'))
         await conn.close()
+
+        data = await conn.gather()
 
         # Echo the data we read back so that the other side can confirm that
         # what it sent is what was received.
         msg = slixmpp.stanza.Message()
         msg = self.client.make_message(
             mto=self.args.j,
-            mbody=self.data.decode('utf-8'),
+            mbody=data.decode('utf-8'),
         )
         msg.appendxml(ET.Element('doneibb'))
         msg.send()
@@ -52,7 +48,6 @@ class SendIBB(Daemon):
 class RecvIBB(Daemon):
     def __init__(self) -> None:
         super().__init__()
-        self.data = bytearray()
         self.conn = Future()
 
     def prepare_argparse(self) -> None:
@@ -71,18 +66,9 @@ class RecvIBB(Daemon):
 
     def configure(self) -> None:
         super().configure()
-        self.end = Future()
         self.client.register_plugin('xep_0047', {
             'auto_accept': True,
         })
-        self.client.add_event_handler(
-            "ibb_stream_data",
-            lambda stream: self.data.extend(stream.recv_queue.get_nowait()),
-        )
-        self.client.add_event_handler(
-            "ibb_stream_end",
-            lambda stream: self.end.set_result(True)
-        )
         self.client.add_event_handler("ibb_stream_start", lambda conn: self.conn.set_result(conn))
 
     async def run(self) -> None:
@@ -93,21 +79,20 @@ class RecvIBB(Daemon):
         msg = slixmpp.stanza.Message()
         msg = self.client.make_message(
             mto=self.args.j,
-            mbody=self.data.decode('utf-8'),
         )
         msg.appendxml(ET.Element('startibb'))
         msg.send()
 
         conn = await self.conn
         await conn.sendall(b"I feel a deep security in the single-mindedness of freight trains.")
-        await self.end
+        data = await conn.gather()
 
         # Echo the data we read back so that the other side can confirm that
         # what it sent is what was received.
         msg = slixmpp.stanza.Message()
         msg = self.client.make_message(
             mto=self.args.j,
-            mbody=self.data.decode('utf-8'),
+            mbody=data.decode('utf-8'),
         )
         msg.appendxml(ET.Element('doneibb'))
         msg.send()


### PR DESCRIPTION
This patch set adds the ability to restrict buffer growth on IBB streams. Its merge is blocked until [poezio@lab.louiz.org/slixmpp#179](https://lab.louiz.org/poezio/slixmpp/-/merge_requests/179) is merged.