### PR TITLE
websocket: fix incorrect TLS host verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Security
+
+- websocket: fix an issue where the wrong hostname was validated in connections
+             made after looking up DNS TXT records, resulting in a potential
+             MITM. A CVE has been issued with the id [CVE-2022-24968].
+
+[CVE-2022-24968]: https://mellium.im/cve/cve-2022-24968/
+
+
 ## v0.21.0 — 2022-02-08
 
 ### Breaking


### PR DESCRIPTION
Previously after fetching a websocket connection endpoint from a DNS TXT
record we were verifying the certificate against the name fetched from
the record. This is incorrect and results in the ability to MITM the
connection because if DNS is spoofed and the WSS endpoint is changed to
evil.example.net we would verify that evil.example.net presented a valid
certificate for itself, but not for good.example.net (or whatever the
original address was expecting). Instead, verify the original address.

This issue has been given CVE ID `CVE-2022-24968` and a write up is available here: https://mellium.im/cve/cve-2022-24968/