### PR TITLE
internal/discover: rewrite WebSocket lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file.
 - xmpp: ability to create informational-only stream features
 
 
+### Fixed
+
+- websocket: rewrote WebSocket discovery to remove TXT record lookups and fix
+  broken XRD file lookups.
+
 [XEP-0115: Entity Capabilities]: https://xmpp.org/extensions/xep-0115.html
 [XEP-0402: PEP Native Bookmarks]: https://xmpp.org/extensions/xep-0402.html
 


### PR DESCRIPTION
This removes the obsoleted DNS TXT record lookup method and fixes the
broken XRD file lookup.

Signed-off-by: Sam Whited <sam@samwhited.com>