### PR TITLE
xmpp: add informational stream features API

### DIFF
--- a/features.go
+++ b/features.go
@@ -198,10 +198,11 @@ func negotiateFeatures(ctx context.Context, s *Session, first, ws bool, features
 				}
 			}
 
-			// If the feature was not sent or was already negotiated, error.
+			// If the feature was not sent, was already negotiated, or is
+			// informational only and not meant to be negotiated: error.
 			_, negotiated := s.negotiated[start.Name.Space]
 			data, sent = list.cache[start.Name.Space]
-			if !sent || negotiated {
+			if !sent || negotiated || data.feature.Negotiate == nil {
 				// TODO: What should we return here?
 				return mask, rw, stream.PolicyViolation
 			}
@@ -233,8 +234,9 @@ func negotiateFeatures(ctx context.Context, s *Session, first, ws bool, features
 				// If we're the client, iterate through the cached features and select
 				// one to negotiate.
 				for _, v := range list.cache {
-					if _, ok := s.negotiated[v.feature.Name.Space]; ok {
-						// If this feature has already been negotiated, skip it.
+					if _, ok := s.negotiated[v.feature.Name.Space]; ok || v.feature.Negotiate == nil {
+						// If this feature has already been negotiated, or is informational
+						// only with no negotiation, skip it.
 						continue
 					}
 


### PR DESCRIPTION
Previously all stream features would be negotiated if they were
supported by both the client and the server.
However, some stream features such as the one specified in XEP-0115:
Entity Capabilities [1] for advertising the servers capabilities are not
meant to be negotiated, they are informational only.
To allow this, skip negotiation of any feature that does not actually
have a Negotiate function, making informational stream features as
simple as not setting this function to a non-nil value.

[1]: https://xmpp.org/extensions/xep-0115.html#stream

Fixes #263

Signed-off-by: Sam Whited <sam@samwhited.com>