### PR TITLE
mux: add ability to add features without handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - bookmarks: new package implementing [XEP-0402: PEP Native Bookmarks]
 - disco: add support for calculating and receiving [XEP-0115: Entity
   Capabilities] hashes
+- mux: add ability to advertise features and identities that do not correspond
+  to a handler
 - xmpp: ability to create informational-only stream features
 
 

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -55,6 +55,8 @@ type ServeMux struct {
 	iqPatterns       map[pattern]IQHandler
 	msgPatterns      map[pattern]MessageHandler
 	presencePatterns map[pattern]PresenceHandler
+	features         []info.FeatureIter
+	idents           []info.IdentityIter
 	stanzaNS         string
 }
 
@@ -285,6 +287,12 @@ func (m *ServeMux) ForFeatures(node string, f func(info.Feature) error) error {
 			}
 		}
 	}
+	for _, iter := range m.features {
+		err := iter.ForFeatures(node, f)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -321,6 +329,12 @@ func (m *ServeMux) ForIdentities(node string, f func(info.Identity) error) error
 			if err != nil {
 				return err
 			}
+		}
+	}
+	for _, iter := range m.idents {
+		err := iter.ForIdentities(node, f)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/mux/option.go
+++ b/mux/option.go
@@ -8,6 +8,7 @@ import (
 	"encoding/xml"
 
 	"mellium.im/xmpp"
+	"mellium.im/xmpp/disco/info"
 	"mellium.im/xmpp/stanza"
 )
 
@@ -82,6 +83,34 @@ func Presence(typ stanza.PresenceType, payload xml.Name, h PresenceHandler) Opti
 // For more information see Presence.
 func PresenceFunc(typ stanza.PresenceType, payload xml.Name, h PresenceHandlerFunc) Option {
 	return Presence(typ, payload, h)
+}
+
+// Feature registers the provided features for service discovery.
+//
+// Most features will be implemented by Handlers and do not need to be
+// registered again, Feature is just for features that should be advertised but
+// do not have any corresponding handler.
+func Feature(iter info.FeatureIter) Option {
+	if iter == nil {
+		panic("mux: nil info.FeatureIter")
+	}
+	return func(m *ServeMux) {
+		m.features = append(m.features, iter)
+	}
+}
+
+// Ident registers the provided identities for service discovery.
+//
+// Most identities will be implemented by Handlers and do not need to be
+// registered again, Ident is just for features that should be advertised but do
+// not have any corresponding handler.
+func Ident(iter info.IdentityIter) Option {
+	if iter == nil {
+		panic("mux: nil info.IdentityIter")
+	}
+	return func(m *ServeMux) {
+		m.idents = append(m.idents, iter)
+	}
 }
 
 // Handle returns an option that matches on the provided XML name.


### PR DESCRIPTION
Previously we could only add features when adding a handler.
Some features, however, may not actually correspond to any particular
query or data transmission and are informational only.
This adds the ability to register types other than the handler types
that implement features or identities.

Signed-off-by: Sam Whited <sam@samwhited.com>