### PR TITLE
disco: use the new crypto package for caps

### DIFF
--- a/disco/caps_test.go
+++ b/disco/caps_test.go
@@ -2,35 +2,40 @@
 // Use of this source code is governed by the BSD 2-clause
 // license that can be found in the LICENSE file.
 
-package disco
+package disco_test
 
 import (
 	"crypto/sha1"
+	"encoding/xml"
 	"hash"
 	"strconv"
 	"testing"
 
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp/crypto"
+	"mellium.im/xmpp/disco"
 	"mellium.im/xmpp/disco/info"
 	"mellium.im/xmpp/form"
+	"mellium.im/xmpp/internal/xmpptest"
 	"mellium.im/xmpp/muc"
 )
 
 var verificationTestCases = [...]struct {
-	info Info
+	info disco.Info
 	h    hash.Hash
 	out  string
 }{
 	0: {
-		info: Info{
+		info: disco.Info{
 			Identity: []info.Identity{{
 				Type:     "pc",
 				Category: "client",
 				Name:     "Exodus 0.9.1",
 			}},
 			Features: []info.Feature{
-				{Var: NSInfo},
-				{Var: NSCaps},
-				{Var: NSItems},
+				{Var: disco.NSInfo},
+				{Var: disco.NSCaps},
+				{Var: disco.NSItems},
 				{Var: muc.NS},
 			},
 		},
@@ -38,7 +43,7 @@ var verificationTestCases = [...]struct {
 		out: `QgayPKawpkPSDYmwT/WM94uAlu0=`,
 	},
 	1: {
-		info: Info{
+		info: disco.Info{
 			Identity: []info.Identity{
 				{
 					Lang:     "en",
@@ -54,9 +59,9 @@ var verificationTestCases = [...]struct {
 				},
 			},
 			Features: []info.Feature{
-				{Var: NSInfo},
-				{Var: NSCaps},
-				{Var: NSItems},
+				{Var: disco.NSInfo},
+				{Var: disco.NSCaps},
+				{Var: disco.NSItems},
 				{Var: muc.NS},
 			},
 			Form: []form.Data{*form.New(
@@ -84,4 +89,67 @@ func TestVerification(t *testing.T) {
 		})
 	}
 
+}
+
+// Normally tests call TokenReader by virtue of MarshalXML being implemented in
+// terms of WriteXML which is implemented in terms of TokenReader.
+// Unfortunately, in this case this isn't true (TokenReader and WriteXML are
+// both implemented in terms of an internal function due to error handling
+// differences). This type lets us mask out the WriteXML and MarshalXML
+// implementations so that the marshal tests always call TokenReader, regardless
+// of how MarshalXML is implemented.
+type marshalTokenReader struct {
+	m xmlstream.Marshaler
+}
+
+func (m marshalTokenReader) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
+	_, err := xmlstream.Copy(e, m.m.TokenReader())
+	return err
+}
+
+var marshalTestCases = []xmpptest.EncodingTestCase{
+	0: {
+		NoUnmarshal: true,
+		Value:       &disco.Caps{},
+		Err:         crypto.ErrUnknownAlgo,
+	},
+	1: {
+		NoMarshal: true,
+		Value:     &disco.Caps{},
+		XML:       `<c xmlns="http://jabber.org/protocol/caps" hash="" node="" ver=""></c>`,
+		Err:       crypto.ErrUnknownAlgo,
+	},
+	2: {
+		Value: &disco.Caps{
+			Hash: crypto.SHA1,
+			Node: "node",
+			Ver:  "ver",
+		},
+		XML: `<c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="node" ver="ver"></c>`,
+	},
+	3: {
+		NoUnmarshal: true,
+		Value: marshalTokenReader{
+			m: &disco.Caps{
+				Hash: crypto.SHA1,
+				Node: "node",
+				Ver:  "ver",
+			},
+		},
+		XML: `<c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="node" ver="ver"></c>`,
+	},
+	4: {
+		NoUnmarshal: true,
+		Value: marshalTokenReader{
+			m: &disco.Caps{
+				Node: "node",
+				Ver:  "ver",
+			},
+		},
+		XML: `<c xmlns="http://jabber.org/protocol/caps" node="node" ver="ver"></c>`,
+	},
+}
+
+func TestEncode(t *testing.T) {
+	xmpptest.RunEncodingTests(t, marshalTestCases)
 }


### PR DESCRIPTION
This patch uses the new [`crypto`] package for entity caps, ensuring that we only use supported algorithms and that marshaling and unmarshaling is correct.

[`crypto`]: https://pkg.go.dev/mellium.im/xmpp/crypto