### PR TITLE
Fix direct invites

### DIFF
--- a/history/history.go
+++ b/history/history.go
@@ -22,7 +22,7 @@ import (
 // results.
 func Handle(h *Handler) mux.Option {
 	return func(m *mux.ServeMux) {
-		mux.Message("", xml.Name{Space: NS, Local: "result"}, h)(m)
+		mux.Message(stanza.NormalMessage, xml.Name{Space: NS, Local: "result"}, h)(m)
 	}
 }
 

--- a/ibb/ibb.go
+++ b/ibb/ibb.go
@@ -49,7 +49,7 @@ const (
 func Handle(h *Handler) mux.Option {
 	data := xml.Name{Space: NS, Local: "data"}
 	return func(m *mux.ServeMux) {
-		mux.Message("", data, h)(m)
+		mux.Message(stanza.NormalMessage, data, h)(m)
 		mux.IQ(stanza.SetIQ, data, h)(m)
 		mux.IQ(stanza.SetIQ, xml.Name{Space: NS, Local: "open"}, h)(m)
 		mux.IQ(stanza.SetIQ, xml.Name{Space: NS, Local: "close"}, h)(m)

--- a/ibb/integration_test.go
+++ b/ibb/integration_test.go
@@ -164,7 +164,7 @@ func integrationRecv(session *xmpp.Session) func(context.Context, *testing.T, *i
 			m := mux.New(
 				stanza.NSClient,
 				ibb.Handle(ibbHandler),
-				mux.MessageFunc("", xml.Name{Local: "doneibb"}, func(msg stanza.Message, r xmlstream.TokenReadEncoder) error {
+				mux.MessageFunc(stanza.NormalMessage, xml.Name{Local: "doneibb"}, func(msg stanza.Message, r xmlstream.TokenReadEncoder) error {
 					bodyMessage := struct {
 						stanza.Message
 						Body string `xml:"body"`
@@ -222,11 +222,11 @@ func integrationSend(session *xmpp.Session, sid string) func(context.Context, *t
 			m := mux.New(
 				stanza.NSClient,
 				ibb.Handle(ibbHandler),
-				mux.MessageFunc("", xml.Name{Local: "startibb"}, func(msg stanza.Message, _ xmlstream.TokenReadEncoder) error {
+				mux.MessageFunc(stanza.NormalMessage, xml.Name{Local: "startibb"}, func(msg stanza.Message, _ xmlstream.TokenReadEncoder) error {
 					j <- msg.From
 					return nil
 				}),
-				mux.MessageFunc("", xml.Name{Local: "doneibb"}, func(msg stanza.Message, r xmlstream.TokenReadEncoder) error {
+				mux.MessageFunc(stanza.NormalMessage, xml.Name{Local: "doneibb"}, func(msg stanza.Message, r xmlstream.TokenReadEncoder) error {
 					bodyMessage := struct {
 						stanza.Message
 						Body string `xml:"body"`

--- a/stanza/message_test.go
+++ b/stanza/message_test.go
@@ -25,11 +25,12 @@ func TestMarshalMessageTypeAttr(t *testing.T) {
 		value       string
 		err         error
 	}{
-		0: {stanza.MessageType(""), "", nil},
+		0: {stanza.MessageType(""), "normal", nil},
 		1: {stanza.NormalMessage, "normal", nil},
 		2: {stanza.ChatMessage, "chat", nil},
 		3: {stanza.HeadlineMessage, "headline", nil},
 		4: {stanza.ErrorMessage, "error", nil},
+		5: {stanza.MessageType("foo"), "normal", nil},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			b, err := xml.Marshal(stanza.Message{Type: tc.messagetype})
@@ -161,8 +162,12 @@ func TestMessageFromStartElement(t *testing.T) {
 			if langAttr.Value != msg.Lang {
 				t.Errorf("wrong value for xml:lang: want=%q, got=%q", langAttr.Value, msg.Lang)
 			}
-			if _, v := attr.Get(tc.Attr, "type"); v != string(msg.Type) {
-				t.Errorf("wrong value for type: want=%q, got=%q", v, msg.Type)
+			exists, typeAttr := attr.Get(tc.Attr, "type")
+			if exists == -1 {
+				typeAttr = "normal"
+			}
+			if typeAttr != string(msg.Type) {
+				t.Errorf("wrong value for type: want=%q, got=%q", typeAttr, msg.Type)
 			}
 		})
 	}


### PR DESCRIPTION
ATM, `HandleInvite` expects message type of `normal` for direct MUC invitations, but as per XEP-0249, type is omitted from the message. So this PR adds an empty message type, and uses that in `HandleInvite`.

Thanks!