### PR TITLE
.builds: use python-slixmpp package in tests

### DIFF
--- a/.builds/integration.yml
+++ b/.builds/integration.yml
@@ -11,11 +11,8 @@ packages:
   - openssl
   - prosody
   - python-pip
+  - python-slixmpp
   - sendxmpp
-  # We cannot use a released version of Slixmpp because no released version
-  # currently supports Python 3.10 or greater.
-  # See: https://lab.louiz.org/poezio/slixmpp/-/issues/3467
-  - python-slixmpp-git
 sources:
   - https://git.sr.ht/~samwhited/xmpp
 environment:


### PR DESCRIPTION
Now that v1.8.0 of Slixmpp has been released with Python 3.10 support we can move
back off the Git package to a stable version.

Fixes #257

Signed-off-by: Sam Whited <sam@samwhited.com>