### PR TITLE
internal/discover: minor fixes to XRD lookup

### DIFF
--- a/internal/discover/lookup.go
+++ b/internal/discover/lookup.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -215,6 +216,8 @@ func getHostMetaXML(ctx context.Context, client *http.Client, name string) (xrd 
 	if err != nil {
 		return xrd, err
 	}
-	err = xml.NewDecoder(resp.Body).Decode(&xrd)
+	// If the server sends us a lot of data it's probably good to just error out.
+	body := io.LimitReader(resp.Body, http.DefaultMaxHeaderBytes)
+	err = xml.NewDecoder(body).Decode(&xrd)
 	return xrd, err
 }

--- a/internal/discover/lookup.go
+++ b/internal/discover/lookup.go
@@ -216,6 +216,8 @@ func getHostMetaXML(ctx context.Context, client *http.Client, name string) (xrd 
 	if err != nil {
 		return xrd, err
 	}
+	/* #nosec */
+	defer resp.Body.Close()
 	// If the server sends us a lot of data it's probably good to just error out.
 	body := io.LimitReader(resp.Body, http.DefaultMaxHeaderBytes)
 	err = xml.NewDecoder(body).Decode(&xrd)


### PR DESCRIPTION
These patches fix two bugs with XRD lookup: the file size was not limited, and the body was not closed. Both are potential resource leaks.