### PR TITLE
ibb: add API to listen for specific connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- ibb: the `Expect` method can be used to accept only pre-negotiated IBB
+  sessions
+
+
 ### Breaking
 
 - compress: the compress package has been removed; users of this package can
   find a drop in replacement at [mellium.im/legacy/compress]
+- ibb: the `Listener` type is now a pointer type
 
 
 ### Fixed

--- a/ibb/listen.go
+++ b/ibb/listen.go
@@ -5,24 +5,34 @@
 package ibb
 
 import (
+	"context"
 	"errors"
 	"net"
+	"sync"
 
 	"mellium.im/xmpp"
+	"mellium.im/xmpp/jid"
 )
+
+type expected struct {
+	c      chan *Conn
+	cancel context.CancelFunc
+}
 
 // Listener is an implementation of net.Listener that is used to accept
 // incoming IBB streams.
 type Listener struct {
-	s *xmpp.Session
-	h *Handler
-	c chan *Conn
+	s        *xmpp.Session
+	h        *Handler
+	c        chan *Conn
+	expected map[string]expected
+	eLock    sync.Mutex
 }
 
 // Accept waits for the next incoming IBB stream and returns the connection.
 // If the listener is closed by either end pending Accept calls unblock and
 // return an error.
-func (l Listener) Accept() (net.Conn, error) {
+func (l *Listener) Accept() (net.Conn, error) {
 	conn, ok := <-l.c
 	if !ok {
 		return nil, errors.New("ibb: accept on closed listener")
@@ -30,10 +40,43 @@ func (l Listener) Accept() (net.Conn, error) {
 	return conn, nil
 }
 
+// Expect is like Accept except that it accepts a specific session that has been
+// negotiated out-of-band.
+// If Accept and Expect are both waiting on connections, Expect will take
+// precedence.
+// If Expect is called twice for the same session the original call will be
+// canceled and return a context error and the new Expect call will take over.
+func (l *Listener) Expect(ctx context.Context, from jid.JID, sid string) (net.Conn, error) {
+	l.eLock.Lock()
+	if l.expected == nil {
+		l.expected = make(map[string]expected)
+	}
+	key := from.String() + ":" + sid
+	e, ok := l.expected[key]
+	if ok {
+		e.cancel()
+	}
+	e.c = make(chan *Conn)
+	ctx, cancel := context.WithCancel(ctx)
+	e.cancel = cancel
+	l.expected[key] = e
+	l.eLock.Unlock()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case conn, ok := <-e.c:
+		if !ok {
+			return nil, errors.New("ibb: accept on closed listener")
+		}
+		return conn, nil
+	}
+}
+
 // Close stops listening and causes any pending Accept calls to unblock and
 // return an error.
 // Already accepted connections are not closed.
-func (l Listener) Close() error {
+func (l *Listener) Close() error {
 	l.h.lM.Lock()
 	defer l.h.lM.Unlock()
 	delete(l.h.l, l.s.LocalAddr().String())
@@ -43,6 +86,6 @@ func (l Listener) Close() error {
 
 // Addr returns the local address for which this listener is accepting
 // connections.
-func (l Listener) Addr() net.Addr {
+func (l *Listener) Addr() net.Addr {
 	return l.s.LocalAddr()
 }


### PR DESCRIPTION
Most IBB sessions will be negotiated out of band, however there was
previously no API for accepting a specific pre-negotiated session.

Fixes #240

Signed-off-by: Sam Whited <sam@samwhited.com>