### PR TITLE
all: run gofmt for Go 1.19 doc comments

### DIFF
--- a/blocklist/blocking.go
+++ b/blocklist/blocking.go
@@ -24,10 +24,10 @@ const NS = `urn:xmpp:blocklist`
 // The JID matches the blocklist JID if any of the following compare to the
 // blocklist JID (falling back in this order):
 //
-//  - Full JID (user@domain/resource)
-//  - Bare JID (user@domain)
-//  - Full domain (domain/resource)
-//  - Bare domain
+//   - Full JID (user@domain/resource)
+//   - Bare JID (user@domain)
+//   - Full domain (domain/resource)
+//   - Bare domain
 func Match(j1, j2 jid.JID) bool {
 	return j1.Equal(j2) ||
 		j1.Bare().Equal(j2) ||

--- a/doc.go
+++ b/doc.go
@@ -15,12 +15,12 @@
 // for creating your own multiplexers, and the stanza package which provides
 // functionality for transmitting XMPP primitives and errors.
 //
-// Session Negotiation
+// # Session Negotiation
 //
 // There are 9 functions for establishing an XMPP session.
 // Their names are matched by the regular expression:
 //
-//     (New|Receive|Dial)(Client|Server)?Session
+//	(New|Receive|Dial)(Client|Server)?Session
 //
 // If "Dial" is present it means the function uses sane defaults to dial a TCP
 // connection before negotiating an XMPP session on it.
@@ -28,13 +28,13 @@
 // a client-to-server (c2s) or server-to-server (s2s) connection respectively.
 // These methods are the most convenient way to quickly start a connection.
 //
-//     session, err := xmpp.DialClientSession(
-//         context.TODO(),
-//         jid.MustParse("me@example.net"),
-//         xmpp.StartTLS(&tls.Config{…}),
-//         xmpp.SASL("", pass, sasl.ScramSha1Plus, sasl.ScramSha1, sasl.Plain),
-//         xmpp.BindResource(),
-//     )
+//	session, err := xmpp.DialClientSession(
+//	    context.TODO(),
+//	    jid.MustParse("me@example.net"),
+//	    xmpp.StartTLS(&tls.Config{…}),
+//	    xmpp.SASL("", pass, sasl.ScramSha1Plus, sasl.ScramSha1, sasl.Plain),
+//	    xmpp.BindResource(),
+//	)
 //
 // If control over DNS or HTTP-based service discovery is desired, the user can
 // use the dial package to create a connection and then use one of the other
@@ -53,17 +53,17 @@
 // such as the WebSocket subprotocol from the websocket package, or the Jabber
 // Component Protocol from the component package.
 //
-//     conn, err := dial.Client(context.TODO(), "tcp", addr)
-//     …
-//     session, err := xmpp.NewSession(
-//         context.TODO(), addr.Domain(), addr, conn, xmpp.Secure,
-//         xmpp.NewNegotiator(func(*xmpp.Session, *xmpp.StreamConfig) {
-//             return xmpp.StreamConfig{
-//                 Lang: "en",
-//                 …
-//             },
-//         }),
-//     )
+//	conn, err := dial.Client(context.TODO(), "tcp", addr)
+//	…
+//	session, err := xmpp.NewSession(
+//	    context.TODO(), addr.Domain(), addr, conn, xmpp.Secure,
+//	    xmpp.NewNegotiator(func(*xmpp.Session, *xmpp.StreamConfig) {
+//	        return xmpp.StreamConfig{
+//	            Lang: "en",
+//	            …
+//	        },
+//	    }),
+//	)
 //
 // The default Negotiator and related functions use a list of StreamFeature's to
 // negotiate the state of the session.
@@ -73,7 +73,7 @@
 // StreamFeatures defined in this module are safe for concurrent use by multiple
 // goroutines and may be created once and then re-used.
 //
-// Handling Stanzas
+// # Handling Stanzas
 //
 // Unlike HTTP, the XMPP protocol is asynchronous, meaning that both clients and
 // servers can accept and send requests at any time and responses are not always
@@ -97,13 +97,13 @@
 // events over the output stream.
 // Their names are matched by the regular expression:
 //
-//     (Send|Encode)(Message|Presence|IQ)?(Element)?
+//	(Send|Encode)(Message|Presence|IQ)?(Element)?
 //
 // There are also four methods specifically for sending IQs and handling their
 // responses.
 // Their names are matched by:
 //
-//     (Unmarshal|Iter)IQ(Element)?
+//	(Unmarshal|Iter)IQ(Element)?
 //
 // If "Send" is present it means that the method copies one XML token stream
 // into the output stream, while "Encode" indicates that it takes a value and
@@ -114,8 +114,8 @@
 // and not the full element to be transmitted and that it should be wrapped in
 // the provided start element token or stanza.
 //
-//     // Send initial presence to let the server know we want to receive messages.
-//     _, err = session.Send(context.TODO(), stanza.Presence{}.Wrap(nil))
+//	// Send initial presence to let the server know we want to receive messages.
+//	_, err = session.Send(context.TODO(), stanza.Presence{}.Wrap(nil))
 //
 // For SendIQ and related methods to correctly handle IQ responses, and to make
 // the common case of polling for incoming XML on the input stream—and possibly
@@ -128,24 +128,24 @@
 // stream to the end of the element when the handler returns (even if the
 // handler did not consume the entire element).
 //
-//     err := session.Serve(xmpp.HandlerFunc(func(t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
-//         d := xml.NewTokenDecoder(t)
+//	err := session.Serve(xmpp.HandlerFunc(func(t xmlstream.TokenReadEncoder, start *xml.StartElement) error {
+//	    d := xml.NewTokenDecoder(t)
 //
-//         // Ignore anything that's not a message.
-//         if start.Name.Local != "message" {
-//             return nil
-//         }
+//	    // Ignore anything that's not a message.
+//	    if start.Name.Local != "message" {
+//	        return nil
+//	    }
 //
-//         msg := struct {
-//             stanza.Message
-//             Body string `xml:"body"`
-//         }{}
-//         err := d.DecodeElement(&msg, start)
-//         …
-//         if msg.Body != "" {
-//             log.Println("Got message: %q", msg.Body)
-//         }
-//     }))
+//	    msg := struct {
+//	        stanza.Message
+//	        Body string `xml:"body"`
+//	    }{}
+//	    err := d.DecodeElement(&msg, start)
+//	    …
+//	    if msg.Body != "" {
+//	        log.Println("Got message: %q", msg.Body)
+//	    }
+//	}))
 //
 // It isn't always practical to put all of your logic for handling elements into
 // a single function or method, so the mux package contains an XML multiplexer

--- a/examples/echobot/main.go
+++ b/examples/echobot/main.go
@@ -7,7 +7,7 @@
 //
 // For more information try running:
 //
-//     echobot -help
+//	echobot -help
 package main
 
 import (

--- a/internal/discover/lookup.go
+++ b/internal/discover/lookup.go
@@ -28,15 +28,15 @@ const (
 
 // XRD represents an Extensible Resource Descriptor document of the form:
 //
-//    <?xml version='1.0' encoding=utf-9'?>
-//    <XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>
-//      …
-//      <Link rel="urn:xmpp:alt-connections:xbosh"
-//            href="https://web.example.com:5280/bosh" />
-//      <Link rel="urn:xmpp:alt-connections:websocket"
-//            href="wss://web.example.com:443/ws" />
-//      …
-//    </XRD>
+//	<?xml version='1.0' encoding=utf-9'?>
+//	<XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>
+//	  …
+//	  <Link rel="urn:xmpp:alt-connections:xbosh"
+//	        href="https://web.example.com:5280/bosh" />
+//	  <Link rel="urn:xmpp:alt-connections:websocket"
+//	        href="wss://web.example.com:443/ws" />
+//	  …
+//	</XRD>
 //
 // as defined by RFC 6415 and OASIS.XRD-1.0.
 type XRD struct {

--- a/internal/integration/aioxmpp/aioxmpp.go
+++ b/internal/integration/aioxmpp/aioxmpp.go
@@ -10,24 +10,24 @@
 // method can be used to add command line arguments to the Python scripts.
 // For example:
 //
-//     from aioxmpp_client import Daemon
-//     import aioxmpp
+//	from aioxmpp_client import Daemon
+//	import aioxmpp
 //
 //
-//     class Ping(Daemon):
-//         def prepare_argparse(self) -> None:
-//             super().prepare_argparse()
+//	class Ping(Daemon):
+//	    def prepare_argparse(self) -> None:
+//	        super().prepare_argparse()
 //
-//             def jid(s):
-//                 return aioxmpp.JID.fromstr(s)
-//             self.argparse.add_argument(
-//                 "-j",
-//                 type=jid,
-//                 help="The JID to ping",
-//             )
+//	        def jid(s):
+//	            return aioxmpp.JID.fromstr(s)
+//	        self.argparse.add_argument(
+//	            "-j",
+//	            type=jid,
+//	            help="The JID to ping",
+//	        )
 //
-//         async def run(self) -> None:
-//             await aioxmpp.ping.ping(self.client, self.args.j)
+//	    async def run(self) -> None:
+//	        await aioxmpp.ping.ping(self.client, self.args.j)
 //
 // For more information see aioxmpp_client.py, python/xmpptest.py, and the
 // aioxmpp documentation.

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -7,7 +7,7 @@
 // The integration test package should normally be used from within a file that
 // does not build unless integration tests are being run:
 //
-//     //go:build integration
+//	//go:build integration
 //
 // It should also normally be used from within a test containing the term
 // "Integration".
@@ -28,20 +28,20 @@
 // For example, running two tests against Prosody and one against Ejabberd might
 // look like the following:
 //
-//     func TestIntegrationSendPing(t *testing.T) {
-//     	prosodyRun := prosody.Test(context.TODO(), t,
-//     		integration.Log(),
-//     		prosody.ListenC2S(),
-//     	)
-//     	prosodyRun(integrationSendPing)
-//     	prosodyRun(integrationRecvPing)
+//	func TestIntegrationSendPing(t *testing.T) {
+//		prosodyRun := prosody.Test(context.TODO(), t,
+//			integration.Log(),
+//			prosody.ListenC2S(),
+//		)
+//		prosodyRun(integrationSendPing)
+//		prosodyRun(integrationRecvPing)
 //
-//     	ejabberdRun := ejabberd.Test(context.TODO(), t,
-//     		integration.Log(),
-//     		ejabberd.ListenC2S(),
-//     	)
-//     	ejabberdRun(integrationSendPing)
-//     }
+//		ejabberdRun := ejabberd.Test(context.TODO(), t,
+//			integration.Log(),
+//			ejabberd.ListenC2S(),
+//		)
+//		ejabberdRun(integrationSendPing)
+//	}
 //
 // For more information see the SubtestRunner type and the various Option
 // functions.
@@ -54,15 +54,15 @@
 // DialClient shortcut to quickly create a connection to the prosody server spun
 // up for the test.
 //
-//     func integrationSendPing(ctx context.Context, t *testing.T, cmd *integration.Cmd) {
-//     	j, pass := cmd.User()
-//     	session, err := cmd.DialClient(ctx, j, t,
-//     		xmpp.StartTLS(&tls.Config{
-//     			InsecureSkipVerify: true,
-//     		}),
-//     		xmpp.SASL("", pass, sasl.Plain),
-//     		xmpp.BindResource(),
-//     	)
+//	func integrationSendPing(ctx context.Context, t *testing.T, cmd *integration.Cmd) {
+//		j, pass := cmd.User()
+//		session, err := cmd.DialClient(ctx, j, t,
+//			xmpp.StartTLS(&tls.Config{
+//				InsecureSkipVerify: true,
+//			}),
+//			xmpp.SASL("", pass, sasl.Plain),
+//			xmpp.BindResource(),
+//		)
 //
 // For more information see the Cmd type.
 package integration // import "mellium.im/xmpp/internal/integration"

--- a/internal/integration/prosody/prosody.go
+++ b/internal/integration/prosody/prosody.go
@@ -290,14 +290,14 @@ func Modules(mod ...string) integration.Option {
 // As a special case, if v is nil the key is written to the file directly with
 // no equals sign.
 //
-//     -- Set("foo", "bar")
-//     foo = "bar"
+//	-- Set("foo", "bar")
+//	foo = "bar"
 //
-//     -- Set("foo", 123)
-//     foo = 123
+//	-- Set("foo", 123)
+//	foo = 123
 //
-//     -- Set(`Component "conference.example.org" "muc"`, nil)
-//     Component "conference.example.org" "muc"
+//	-- Set(`Component "conference.example.org" "muc"`, nil)
+//	Component "conference.example.org" "muc"
 func Set(key string, v interface{}) integration.Option {
 	return func(cmd *integration.Cmd) error {
 		cfg := getConfig(cmd)

--- a/internal/integration/slixmpp/slixmpp.go
+++ b/internal/integration/slixmpp/slixmpp.go
@@ -11,26 +11,26 @@
 // method can be used to add command line arguments to the Python scripts.
 // For example:
 //
-//     from slixmpp_client import Daemon
-//     import slixmpp
+//	from slixmpp_client import Daemon
+//	import slixmpp
 //
 //
-//     class Ping(Daemon):
-//         def prepare_argparse(self) -> None:
-//             super().prepare_argparse()
+//	class Ping(Daemon):
+//	    def prepare_argparse(self) -> None:
+//	        super().prepare_argparse()
 //
-//             self.argparse.add_argument(
-//                 "-j",
-//                 type=slixmpp.jid.JID,
-//                 help="The JID to ping",
-//             )
+//	        self.argparse.add_argument(
+//	            "-j",
+//	            type=slixmpp.jid.JID,
+//	            help="The JID to ping",
+//	        )
 //
-//         def configure(self):
-//             super().configure()
-//             self.client.register_plugin('xep_0199') # Ping
+//	    def configure(self):
+//	        super().configure()
+//	        self.client.register_plugin('xep_0199') # Ping
 //
-//         async def run(self) -> None:
-//             await self.client.plugin['xep_0199'].ping(jid=self.args.j)
+//	    async def run(self) -> None:
+//	        await self.client.plugin['xep_0199'].ping(jid=self.args.j)
 //
 // For more information see slixmpp_client.py, python/xmpptest.py, and the
 // slixmpp documentation.

--- a/jid/doc.go
+++ b/jid/doc.go
@@ -16,9 +16,9 @@
 // email with the resourcepart appended after a forward slash.
 // For example, the following are all valid JIDs:
 //
-//     shakespeare@example.net
-//     shakespeare@example.net/phone-b5c93ded
-//     example.net
+//	shakespeare@example.net
+//	shakespeare@example.net/phone-b5c93ded
+//	example.net
 //
 // The first represents the account "shakespeare" on the service "example.net",
 // the second represents a specific phone connected to that account, and the

--- a/muc/muc.go
+++ b/muc/muc.go
@@ -21,18 +21,18 @@
 // It is normally registered with a multiplexer such as the one found in the mux
 // package:
 //
-//     mucClient := muc.Client{}
-//     m := mux.New(
-//         muc.HandleClient(mucClient),
-//     )
-//     channel, err := mucClient.Join(…)
+//	mucClient := muc.Client{}
+//	m := mux.New(
+//	    muc.HandleClient(mucClient),
+//	)
+//	channel, err := mucClient.Join(…)
 //
 // Once the Join method has been called the resulting channel type can be used
 // to perform actions on the channel such as setting the subject, rejoining (to
 // force syncronize state), or leaving the channel.
 //
-//     channel, err := mucClient.Join(…)
-//     channel.Subject(context.Background(), "Bridge operation and tactical readiness")
+//	channel, err := mucClient.Join(…)
+//	channel.Subject(context.Background(), "Bridge operation and tactical readiness")
 package muc // import "mellium.im/xmpp/muc"
 
 import (

--- a/oob/oob.go
+++ b/oob/oob.go
@@ -22,15 +22,15 @@ const (
 
 // IQ represents an OOB data query; for instance:
 //
-//     <iq type='set'
-//         from='feste@example.net/asegasd'
-//         to='malvolio@jabber.org/apkjase'
-//         id='asiepjg'>
-//       <query xmlns='jabber:iq:oob'>
-//         <url>https://xmpp.org/images/promo/xmpp_server_guide_2017.pdf</url>
-//         <desc>XMPP Server Setup Guide 2017</desc>
-//       </query>
-//     </iq>
+//	<iq type='set'
+//	    from='feste@example.net/asegasd'
+//	    to='malvolio@jabber.org/apkjase'
+//	    id='asiepjg'>
+//	  <query xmlns='jabber:iq:oob'>
+//	    <url>https://xmpp.org/images/promo/xmpp_server_guide_2017.pdf</url>
+//	    <desc>XMPP Server Setup Guide 2017</desc>
+//	  </query>
+//	</iq>
 type IQ struct {
 	stanza.IQ
 	Query Query

--- a/stanza/doc.go
+++ b/stanza/doc.go
@@ -21,7 +21,7 @@
 // Stanzas created using either API are not guaranteed to be valid or enforce
 // specific stanza semantics.
 //
-// Custom Stanzas
+// # Custom Stanzas
 //
 // The stanza types in this package aren't very useful by themselves. To
 // transmit meaningful data our stanzas must contain a payload.
@@ -32,27 +32,26 @@
 // To implement this in our own code we might create a Ping struct similar to
 // the following:
 //
-//    // PingIQ is an IQ stanza with an XEP-0199: XMPP Ping payload.
-//    type PingIQ struct {
-//        stanza.IQ
+//	// PingIQ is an IQ stanza with an XEP-0199: XMPP Ping payload.
+//	type PingIQ struct {
+//	    stanza.IQ
 //
-//        Ping struct{} `xml:"urn:xmpp:ping ping"`
-//    }
-//
+//	    Ping struct{} `xml:"urn:xmpp:ping ping"`
+//	}
 //
 // For details on marshaling and the use of the xml tag, refer to the
 // encoding/xml package.
 //
 // We could also create a similar stanza with the token stream API:
 //
-//    // PingIQ returns an xml.TokenReader that outputs a new IQ stanza with a
-//    // ping payload.
-//    func PingIQ(id string, to jid.JID) xml.TokenReader {
-//        start := xml.StartElement{Name: xml.Name{Space: "urn:xmpp:ping", Local: "ping"}}
-//        return stanza.IQ{
-//            ID: id,
-//            To: to,
-//            Type: stanza.GetIQ,
-//        }.Wrap(start)
-//    }
+//	// PingIQ returns an xml.TokenReader that outputs a new IQ stanza with a
+//	// ping payload.
+//	func PingIQ(id string, to jid.JID) xml.TokenReader {
+//	    start := xml.StartElement{Name: xml.Name{Space: "urn:xmpp:ping", Local: "ping"}}
+//	    return stanza.IQ{
+//	        ID: id,
+//	        To: to,
+//	        Type: stanza.GetIQ,
+//	    }.Wrap(start)
+//	}
 package stanza // import "mellium.im/xmpp/stanza"

--- a/stream/error.go
+++ b/stream/error.go
@@ -197,9 +197,9 @@ func (s Error) Is(err error) bool {
 // Error satisfies the builtin error interface and returns the name of the
 // StreamError. For instance, given the error:
 //
-//     <stream:error>
-//       <restricted-xml xmlns="urn:ietf:params:xml:ns:xmpp-streams"/>
-//     </stream:error>
+//	<stream:error>
+//	  <restricted-xml xmlns="urn:ietf:params:xml:ns:xmpp-streams"/>
+//	</stream:error>
 //
 // Error() would return "restricted-xml".
 func (s Error) Error() string {

--- a/styling/styling.go
+++ b/styling/styling.go
@@ -13,7 +13,7 @@
 // input and provides you with a bitmask of styles that should be applied to
 // each token.
 //
-// Format
+// # Format
 //
 // Message Styling borrows several familiar formatting options from Markdown
 // (though it is much simpler and not compatible with Markdown parsers).
@@ -28,15 +28,15 @@
 //
 // There are also a few block formats such as a block quotation:
 //
-//     > A quotation
-//     >> Can be multi-level
+//	> A quotation
+//	>> Can be multi-level
 //
 // And a preformatted text block which can have no child blocks, should be
 // displayed in a monospace font, and which should not be re-wrapped:
 //
-//     ```an optional tag may go here.
-//     Lines of pre-formatted text go here.
-//     ```
+//	```an optional tag may go here.
+//	Lines of pre-formatted text go here.
+//	```
 package styling // import "mellium.im/xmpp/styling"
 
 import (


### PR DESCRIPTION
Some changes were made to documentation comments in Go 1.19 including
adding "#" before headers (instead of detecting them with a heuristic),
and indentation using tabs.

This patch is the result of running "gofmt -s -w ." in the project root.

Fixes #298

Signed-off-by: Sam Whited <sam@samwhited.com>